### PR TITLE
Add type safety error messages

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ atomic = true
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = true
-known_third_party = gamla,pygraphviz,pytest,setuptools,toposort
+known_third_party = gamla,pygraphviz,pytest,setuptools,toposort,typeguard

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ atomic = true
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = true
-known_third_party = gamla,pygraphviz,pytest,setuptools,toposort,typeguard
+known_third_party = gamla,immutables,pygraphviz,pytest,setuptools,toposort,typeguard

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To deploy: `python setup.py sdist bdist_wheel; twine upload dist/*; rm -rf dist/
 
 ### Type checking
 
-Use `run.type_check` as the first argument in `run.to_callable_with_side_effect_for_single_and_multiple`.
+The runner will type check all outputs for nodes with return type annotations. In case of a wrong typing, it will log the node at fault.
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,23 @@ A functional composition framework that supports:
 
 To deploy: `python setup.py sdist bdist_wheel; twine upload dist/*; rm -rf dist/;`
 
+### Type checking
+
+Use `run.type_check` as the first argument in `run.to_callable_with_side_effect_for_single_and_multiple`.
+
 ### Debugging
 
-We need graphviz to visualize computation graphs:
+Available debuggers:
 
-```bash
-sudo apt update && apt install graphviz
-pip install pygraphviz
-```
+1. `graphviz.computation_trace`
+1. `mermaid.computation_trace`
+1. `ascii.computation_trace`
 
-Debugging is possible by replacing `to_callable` with `run.to_callable_with_side_effect` with `ascii.computation_trace` as the first argument.
-This will save a file on each graph execution to current working directory.
+To use, replace `to_callable` with `run.to_callable_with_side_effect` with your selected debugger as the first argument.
+
+#### Graphviz debugger
+
+This debugger will save a file on each graph execution to current working directory.
 
 You can use this file in a graph viewer like [gephi](https://gephi.org/).
 Nodes colored red are part of the 'winning' computation path.

--- a/computation_graph/debug/ascii.py
+++ b/computation_graph/debug/ascii.py
@@ -1,5 +1,3 @@
-import logging
-import pprint
 from typing import Callable, Iterable, Tuple
 
 import gamla
@@ -122,4 +120,4 @@ def computation_trace(graph_instance: base_types.GraphType):
             ),
         )
 
-    return gamla.compose_left(computation_trace, pprint.pformat, logging.info)
+    return gamla.compose_left(computation_trace, gamla.debug)

--- a/computation_graph/graph.py
+++ b/computation_graph/graph.py
@@ -169,7 +169,7 @@ get_terminals = gamla.compose_left(
 )
 
 
-def _aggregator_for_terminal(*args) -> base_types.GraphType:
+def _aggregator_for_terminal(*args):
     return tuple(args)
 
 

--- a/computation_graph/graph_test.py
+++ b/computation_graph/graph_test.py
@@ -708,3 +708,27 @@ def test_double_star_signature_considered_unary():
     result = cg(arg1=_ROOT_VALUE)
     assert isinstance(result, base_types.ComputationResult)
     assert result.result[graph.DEFAULT_TERMINAL][0] == (4, 6)
+
+
+# TODO(uri): This file is repeating this function all over, deduplicate.
+def _runner(edges: base_types.GraphType):
+    return run.to_callable(
+        graph.connect_default_terminal(composers.make_first(edges)),
+        frozenset([_GraphTestError]),
+    )().result[graph.DEFAULT_TERMINAL][0]
+
+
+def test_type_safety_messages(caplog):
+    def f(x) -> int:  # Bad typing!
+        return "hello " + x
+
+    assert _runner(composers.make_compose(f, lambda: "world")) == "hello world"
+    assert "TypeError" in caplog.text
+
+
+def test_type_safety_messages_no_overtrigger(caplog):
+    def f(x) -> str:
+        return "hello " + x
+
+    assert _runner(composers.make_compose(f, lambda: "world")) == "hello world"
+    assert "TypeError" not in caplog.text

--- a/computation_graph/graph_test.py
+++ b/computation_graph/graph_test.py
@@ -108,28 +108,18 @@ def _runner(edges: base_types.GraphType, **kwargs):
 
 
 def test_simple():
-    cg = run.to_callable(
-        graph.connect_default_terminal(
-            (graph.make_edge(source=_node1, destination=_node2, key="arg1"),)
-        ),
-        frozenset([_GraphTestError]),
+    result = _runner(
+        (graph.make_edge(source=_node1, destination=_node2, key="arg1"),),
+        arg1=_ROOT_VALUE,
     )
-    result = cg(arg1=_ROOT_VALUE)
-    assert isinstance(result, base_types.ComputationResult)
-    assert result.result[graph.DEFAULT_TERMINAL][0] == f"node2(node1({_ROOT_VALUE}))"
+    assert result == f"node2(node1({_ROOT_VALUE}))"
 
 
 def test_none_as_input():
-    cg = run.to_callable(
-        graph.connect_default_terminal(
-            (graph.make_edge(source=_node1, destination=_node2, key="arg1"),)
-        ),
-        frozenset([_GraphTestError]),
+    result = _runner(
+        (graph.make_edge(source=_node1, destination=_node2, key="arg1"),), arg1=None
     )
-    result = cg(arg1=None)
-
-    assert isinstance(result, base_types.ComputationResult)
-    assert result.result[graph.DEFAULT_TERMINAL][0] == "node2(node1(None))"
+    assert result == "node2(node1(None))"
 
 
 async def test_simple_async():

--- a/computation_graph/graph_test.py
+++ b/computation_graph/graph_test.py
@@ -669,7 +669,6 @@ def test_or_with_sink_that_raises():
         )
     )
     result = run.to_callable(edges, frozenset([_GraphTestError]))(arg1=_ROOT_VALUE)
-
     assert result.result[graph.DEFAULT_TERMINAL][0] == "[node1(root)]"
 
 
@@ -678,7 +677,6 @@ def test_two_terminals():
     edges = graph.connect_default_terminal(composers.make_compose(_node2, _node1))
     terminal2 = graph.make_terminal("TERMINAL2", gamla.wrap_tuple)
     edges += (graph.make_edge(source=_node1, destination=terminal2),)
-
     result = run.to_callable(edges, frozenset([_GraphTestError]))(arg1=_ROOT_VALUE)
     assert result.result[graph.DEFAULT_TERMINAL][0] == "node2(node1(root))"
     assert result.result[terminal2][0] == "node1(root)"

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -337,7 +337,6 @@ def _construct_computation_result(edges: base_types.GraphType, edges_to_node_id)
 
 
 def type_check(node: base_types.ComputationNode, result):
-    """To be used with `to_callable_with_side_effect_for_single_and_multiple`."""
     try:
         return_typing = typing.get_type_hints(node.func).get("return", None)
     except TypeError:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setuptools.setup(
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),
-    install_requires=["gamla>=83", "typeguard", "toposort"],
+    install_requires=["gamla>=103", "typeguard", "toposort"],
     extras_require={"test": ["pygraphviz", "pytest>=5.4.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="computation-graph",
-    version="14",
+    version="15",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),
-    install_requires=["gamla>=83", "toposort"],
+    install_requires=["gamla>=83", "typeguard", "toposort"],
     extras_require={"test": ["pygraphviz", "pytest>=5.4.0"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setuptools.setup(
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),
-    install_requires=["gamla>=103", "typeguard", "toposort"],
+    install_requires=["gamla>=103", "typeguard", "toposort", "immutables"],
     extras_require={"test": ["pygraphviz", "pytest>=5.4.0"]},
 )


### PR DESCRIPTION
This PR will cause error messages to log whenever a computation node returns something that does not fit its return typing.

Caveats:
`ComputationResult` of course (which we intend to remove).

A corresponding change to `gamla` will cause more functions to be annotated, but we need to think about this shape:

`f: Callable[[...], ...] = gamla.compose_left(...)` - this is currently not affecting the composition annotations at runtime.

Wrt runtime, form the checks I did the effects looks negligible, so enabled this by default.