### PR TITLE
Lazily compute abiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A functional composition framework that supports:
 
 1. State - functions which retain state for their next turn of action.
-2. Ambiguity - non deterministic composition with priorities.
-3. Injection of compositions into long pipelines (deep dependency injection).
+2. Prioritized paths - lazily attempt overloaded composition paths according to priorities.
+3. Deep dependency injection - compose a function to a variadic function at the end of an arbitrarily long pipeline.
 4. Non cancerous `asyncio` support.
 
 `pip install computation-graph`

--- a/computation_graph/composers/composers_test.py
+++ b/computation_graph/composers/composers_test.py
@@ -1,0 +1,18 @@
+import time
+
+from computation_graph import composers, graph, run
+
+
+def test_ambiguity_does_not_blow_up():
+    start_time = time.time()
+
+    def g(x):
+        return x
+
+    for _ in range(15):
+        g = composers.make_first(
+            composers.compose_left_unary(g, lambda x: x + "a"),
+            composers.compose_left_unary(g, lambda x: x + "b"),
+        )
+    run.to_callable(graph.connect_default_terminal(g), frozenset())(x="x")
+    assert time.time() - start_time < 1

--- a/computation_graph/composers/composers_test.py
+++ b/computation_graph/composers/composers_test.py
@@ -1,18 +1,20 @@
-import time
-
 from computation_graph import composers, graph, run
 
 
 def test_ambiguity_does_not_blow_up():
-    start_time = time.time()
+    counter = 0
+
+    def increment():
+        nonlocal counter
+        counter += 1
 
     def g(x):
         return x
 
     for _ in range(15):
         g = composers.make_first(
-            composers.compose_left_unary(g, lambda x: x + "a"),
-            composers.compose_left_unary(g, lambda x: x + "b"),
+            composers.compose_left_unary(g, lambda x: increment() or x + "a"),
+            composers.compose_left_unary(g, lambda x: increment() or x + "b"),
         )
     run.to_callable(graph.connect_default_terminal(g), frozenset())(x="x")
-    assert time.time() - start_time < 1
+    assert counter == 30

--- a/computation_graph/graph.py
+++ b/computation_graph/graph.py
@@ -81,7 +81,6 @@ _CallableOrNode = Union[Callable, base_types.ComputationNode]
 
 
 def make_computation_node(func: _CallableOrNode) -> base_types.ComputationNode:
-    assert func is not base_types.ComputationNode
     if isinstance(func, base_types.ComputationNode):
         return func
 

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -580,6 +580,7 @@ def _lift_single_runner_to_run_on_many_options(is_async: bool, f):
         _create_node_run_options,
         (opt_async_gamla.map if is_async else opt_gamla.map)(f),
         opt_gamla.filter(gamla.identity),
+        gamla.take(1),
         dict,
     )
 

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -3,9 +3,6 @@ import collections
 import dataclasses
 import itertools
 import logging
-import pathlib
-import sys
-import traceback
 import typing
 from typing import Any, Callable, Dict, FrozenSet, Iterable, Set, Tuple, Type
 
@@ -655,7 +652,7 @@ def _make_runner(
             _lift_single_runner_to_run_on_many_options(is_async),
             gamla.excepts(
                 (*handled_exceptions, _NotCoherent, base_types.SkipComputationError),
-                opt_gamla.compose_left(type, _log_handled_exception, gamla.just(None)),
+                opt_gamla.compose_left(type, gamla.just(None)),
             ),
             single_node_runner,
             gamla.before(edges_to_node_id),
@@ -711,13 +708,3 @@ to_callable_with_side_effect = gamla.curry(
 # Use the second line if you want to see the winning path in the computation graph (a little slower).
 to_callable = to_callable_with_side_effect(gamla.just(gamla.just(None)))
 # to_callable = to_callable_with_side_effect(graphviz.computation_trace('utterance_computation.dot'))
-
-
-def _log_handled_exception(exception_type: Type[Exception]):
-    _, exception, exception_traceback = sys.exc_info()
-    filename, line_num, func_name, _ = traceback.extract_tb(exception_traceback)[-1]
-    reason = ""
-    if str(exception):
-        reason = f": {exception}"
-    code_location = f"{pathlib.Path(filename).name}:{line_num}"
-    logging.debug(f"'{func_name.strip('_')}' {exception_type}@{code_location}{reason}")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="computation-graph",
-    version="29",
+    version="30",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),


### PR DESCRIPTION
This makes sure the graph works lazily computing paths, which is important for two things:

1. Preventing the user from creating intractable ambiguity (added a test).
2. Better ambiguous path semantics, where we will select edges without considering what happens downstream. This is easier to reason about (aka "sitting buddha bug").