### PR TITLE
fix draw computation graph in graphviz

### DIFF
--- a/computation_graph/trace/graphviz.py
+++ b/computation_graph/trace/graphviz.py
@@ -125,10 +125,16 @@ def computation_trace(
     gviz = union_graphviz(
         [
             computation_graph_to_graphviz(graph_instance),
-            computation_trace_to_graphviz(
-                trace_utils.node_computation_trace(
-                    node_to_results, graph.infer_graph_sink(graph_instance)
-                )
+            *gamla.pipe(
+                graph_instance,
+                graph.get_leaves,
+                gamla.map(
+                    gamla.compose_left(
+                        trace_utils.node_computation_trace(node_to_results),
+                        computation_trace_to_graphviz,
+                    )
+                ),
+                list,
             ),
         ]
     )

--- a/computation_graph/trace/graphviz.py
+++ b/computation_graph/trace/graphviz.py
@@ -134,7 +134,6 @@ def computation_trace(
                         computation_trace_to_graphviz,
                     )
                 ),
-                list,
             ),
         ]
     )

--- a/computation_graph/trace/trace_utils.py
+++ b/computation_graph/trace/trace_utils.py
@@ -5,6 +5,7 @@ import gamla
 from computation_graph import base_types
 
 
+@gamla.curry
 def node_computation_trace(
     node_to_results: Callable, node: base_types.ComputationNode
 ) -> FrozenSet[Tuple[base_types.ComputationNode, base_types.ComputationResult]]:


### PR DESCRIPTION
since we got rid of final_sink, computation_trace didn't work. changed it to draw the trace for each terminal.