### PR TITLE
Fix _assert_no_unwanted_ambiguity

### DIFF
--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -113,10 +113,10 @@ _is_graph_async = opt_gamla.compose_left(
 _assert_no_unwanted_ambiguity = gamla.compose_left(
     base_types.ambiguity_groups,
     gamla.assert_that_with_message(
-        gamla.len_equals(0),
         gamla.wrap_str(
             "There are multiple edges with the same destination, key and priority in the computation graph!: {}"
         ),
+        gamla.len_equals(0),
     ),
 )
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="computation-graph",
     python_requires=">=3",
-    version="46",
+    version="47",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),


### PR DESCRIPTION
In _assert_no_unwanted_ambiguity, the order of parameters for gamla.assert_that_with_message() was wrong.

