### PR TITLE
fix name callable to also rename the code object of the function. fix…

### DIFF
--- a/computation_graph/composers/debug.py
+++ b/computation_graph/composers/debug.py
@@ -43,5 +43,6 @@ debug_log = _debug_with_frame(_debug_log_inner)
 
 
 def name_callable(f: Callable, name: str) -> Callable:
+    f.__code__ = f.__code__.replace(co_name=name)
     f.__name__ = name
     return f

--- a/computation_graph/composers/duplication.py
+++ b/computation_graph/composers/duplication.py
@@ -6,6 +6,7 @@ from typing import Dict
 import gamla
 
 from computation_graph import base_types, graph
+from computation_graph.composers import debug
 
 
 def duplicate_function(func):
@@ -15,14 +16,13 @@ def duplicate_function(func):
         async def inner(*args, **kwargs):
             return await func(*args, **kwargs)
 
-        return inner
+    else:
 
-    @functools.wraps(func)
-    def inner(*args, **kwargs):
-        return func(*args, **kwargs)
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            return func(*args, **kwargs)
 
-    inner.__name__ = f"duplicate of {inner.__name__}"
-    return inner
+    return debug.name_callable(inner, f"duplicate of {func.__name__}")
 
 
 def _duplicate_computation_edge(get_duplicated_node):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="computation-graph",
     python_requires=">=3",
-    version="62",
+    version="63",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),


### PR DESCRIPTION
… duplicate_function to rename the callable also in the case of async