### PR TITLE
CORE-1: cheap node names in lift.always (avoid rendering large lifted values)

### DIFF
--- a/computation_graph/composers/lift.py
+++ b/computation_graph/composers/lift.py
@@ -5,11 +5,19 @@ import gamla
 from computation_graph import base_types, composers
 
 
+def _short_name(x) -> str:
+    if x is None or isinstance(x, (int, float, str)):
+        return f"{x!s:.30}"
+    if isinstance(x, (dict, list, tuple, set, frozenset)):
+        return f"{type(x).__name__}[{len(x)}]"
+    return type(x).__name__
+
+
 def always(x):
     def always():
         return x
 
-    always.__name__ = f"always {x!s:.30}"
+    always.__name__ = f"always {_short_name(x)}"
     return always
 
 

--- a/computation_graph/composers/lift_test.py
+++ b/computation_graph/composers/lift_test.py
@@ -1,0 +1,42 @@
+from computation_graph.composers import lift
+
+
+def test_always_returns_the_value():
+    assert lift.always(5)() == 5
+    obj = {"a": 1}
+    assert lift.always(obj)() is obj
+
+
+def test_always_name_keeps_scalars_readable():
+    assert lift.always(5).__name__ == "always 5"
+    assert lift.always(3.5).__name__ == "always 3.5"
+    assert lift.always("cardiology").__name__ == "always cardiology"
+    assert lift.always(None).__name__ == "always None"
+
+
+def test_always_name_summarizes_containers_by_type_and_length():
+    assert lift.always({"a": 1, "b": 2}).__name__ == "always dict[2]"
+    assert lift.always([1, 2, 3]).__name__ == "always list[3]"
+    assert lift.always((1, 2)).__name__ == "always tuple[2]"
+
+
+def test_always_name_does_not_render_large_container_contents():
+    # The point of the summary: naming a node must not stringify a huge value.
+    name = lift.always({i: i for i in range(10_000)}).__name__
+    assert name == "always dict[10000]"
+
+
+def test_always_name_falls_back_to_type_for_other_objects():
+    class Custom:
+        pass
+
+    assert lift.always(Custom()).__name__ == "always Custom"
+
+
+def test_distinct_always_calls_produce_distinct_nodes_despite_equal_names():
+    # Names are display-only; node identity is hash(func), and every always()
+    # call is a fresh function, so equal names must not collapse two nodes.
+    a, b = lift.always({"x": 1}), lift.always({"y": 2})
+    assert a.__name__ == b.__name__ == "always dict[1]"
+    assert a is not b
+    assert hash(a) != hash(b)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="computation-graph",
     python_requires=">=3",
-    version="64",
+    version="65",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),


### PR DESCRIPTION
## Summary
`lift.always` named its node via `f"always {x!s:.30}"`, which renders the full `str(x)` and *then* slices to 30 chars. Lifting a large value — e.g. a voice screening table whose `str(x)` is ~1.5 GB — built that entire string just to keep 30 characters, dozens of times per build. This was the dominant cost in voice-assistant builds.

Now non-scalars get a cheap `type[len]` name (e.g. `always frozendict[855]`); scalars keep their value as before. Node identity is `hash(self.func)` and `name` is used only in `ComputationNode.__repr__`, so this is display-only and does not change graph structure.

Measured on a real voice assistant: build dropped from ~250s to ~50s with byte-identical output.

## Jira
https://hyro-ai.atlassian.net/browse/CORE-1