### PR TITLE
CORE-08: authoring-time graph coloring (per-turn node pruning)

### DIFF
--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -26,20 +26,27 @@ from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional
 
 from computation_graph import base_types, composers, graph, run
 
+# The three "tags" are kept in PROCESS-LOCAL MAPS keyed by the func object, NOT on
+# `func.__dict__`. `_ORIGIN_ATTR` etc. survive only as the map selectors below.
 _ORIGIN_ATTR = "__cg_origin__"
 _EMPTY_ATTR = "__cg_empty__"
 _OBSERVER_ATTR = "__cg_observer__"
 _UNSET = object()
 
-# Every func stamped by `_tag_func` is registered here so `reset_colors` can strip
-# the tags again. Colors live on the process-global `func.__dict__` (so they ride
-# `duplicate_function`), and MANY funcs are shared BY REFERENCE across bot builds
-# (generic gamla combinators, module-level slot/configurable definitions built once
-# at import). Without a reset, a bot built earlier stamps these shared objects and a
-# bot built LATER inherits the foreign colors -> mis-pruning. The registry lets each
-# build start from a clean slate; see `reset_colors`.
-_TAGGED_FUNCS: set = set()
-_TAG_ATTRS = (_ORIGIN_ATTR, _EMPTY_ATTR, _OBSERVER_ATTR)
+# Colors used to be stamped on the process-global `func.__dict__`. That leaked across
+# bot builds (shared-by-reference funcs -- generic combinators, module-level slot defs
+# -- carried an earlier build's colors into a later one), and clearing the tags per
+# build was ruinously slow under the test runner, which instruments every `__dict__`
+# mutation for dependency tracking (tens of thousands of mutations per build).
+#
+# Instead we keep the tags in module-level MAPS keyed by func. `reset_colors` drops
+# them in O(1) with ZERO per-func mutation, so each build starts clean and nothing
+# touches the shared func objects. Provenance still survives `duplicate_function`:
+# functools.wraps sets `inner.__wrapped__ = original`, so `_resolve` walks the
+# __wrapped__ chain to recover a duplicate's tag from the original it was copied from.
+_COLOR_MAP: Dict = {}  # func -> frozenset(colors)  |  _CORE
+_EMPTY_MAP: Dict = {}  # func -> typed-empty value
+_OBSERVER_MAP: Dict = {}  # func -> True
 
 
 # --------------------------------------------------------------------------- #
@@ -93,35 +100,52 @@ def _sinks(graph_or_edges) -> FrozenSet[base_types.ComputationNode]:
 _CORE = "\x00cg-core"  # absorbing marker; not a usable color token
 
 
+_ATTR_TO_MAP = {
+    _ORIGIN_ATTR: _COLOR_MAP,
+    _EMPTY_ATTR: _EMPTY_MAP,
+    _OBSERVER_ATTR: _OBSERVER_MAP,
+}
+
+
 def _tag_func(func, attr: str, value) -> None:
-    # The one guarded stamp: write `attr = value` onto the func's __dict__ so it rides
-    # `duplicate_function` (functools.wraps copies __dict__). No-op on an un-taggable
-    # builtin / C callable -> it stays tag-less, which the readers treat as core.
-    # Register the func so `reset_colors` can strip every tag it received at the next
-    # build's start (tags leak across builds on shared-by-reference funcs otherwise).
+    # Record `value` for `func` in the map selected by `attr`. Keyed by the func object
+    # (no `func.__dict__` mutation). No-op on an unhashable callable -> it stays
+    # untracked, which the readers treat as core (same as the old un-taggable path).
     try:
-        setattr(func, attr, value)
-    except (AttributeError, TypeError):
-        return
-    _TAGGED_FUNCS.add(func)
+        _ATTR_TO_MAP[attr][func] = value
+    except TypeError:
+        pass
+
+
+def _resolve(func, mapping, default=None):
+    # A duplicate isn't in the map, but functools.wraps set its `__wrapped__` to the
+    # func it was copied from -- walk that chain to recover the tag the original carried
+    # (this is how tags "survive duplication" now that they live off `func.__dict__`).
+    for _ in range(64):  # depth guard against a pathological __wrapped__ cycle
+        try:
+            if func in mapping:
+                return mapping[func]
+        except TypeError:  # unhashable -> untracked
+            return default
+        func = getattr(func, "__wrapped__", None)
+        if func is None:
+            break
+    return default
 
 
 def reset_colors() -> None:
-    """Strip every color/empty/observer tag stamped since the last reset, and forget
-    the funcs that carried them. Call ONCE at the START of each bot build -- before
-    any `add_colors` / `pin_core` / `observer` sweep and before graph construction --
-    so tags stamped by an EARLIER build cannot leak onto shared-by-reference funcs a
-    LATER build reuses (the process-global-`__dict__` contamination). Idempotent; a
-    build that never colored is unaffected. Deliberately NOT called mid-build: a
-    multi-skill bot compiles many subgraphs and clearing between them would leave the
-    later compiles uncolored."""
-    for func in _TAGGED_FUNCS:
-        for attr in _TAG_ATTRS:
-            try:
-                delattr(func, attr)
-            except AttributeError:
-                pass
-    _TAGGED_FUNCS.clear()
+    """Drop every color/empty/observer tag stamped since the last reset. Call ONCE at
+    the START of each bot build -- before any `add_colors` / `pin_core` / `observer`
+    sweep and before graph construction -- so tags stamped by an EARLIER build cannot
+    leak into a LATER build that reuses the same shared-by-reference funcs (generic
+    combinators, module-level slot defs). O(1) and mutation-free (the tags live in
+    module maps, not on the funcs), so it is cheap even under a test runner that
+    instruments `__dict__` writes. Idempotent; a build that never colored is
+    unaffected. Deliberately NOT called mid-build: a multi-skill bot compiles many
+    subgraphs and clearing between them would leave the later compiles uncolored."""
+    _COLOR_MAP.clear()
+    _EMPTY_MAP.clear()
+    _OBSERVER_MAP.clear()
 
 
 def add_colors(
@@ -139,7 +163,7 @@ def add_colors(
     make_first sinks, and terminals -- which the runner merges via make_or) never
     consult it, so only the genuinely intolerant frontier needs an `empty`."""
     for node in _colorable_nodes(subgraph):
-        current = getattr(node.func, _ORIGIN_ATTR, None)
+        current = _resolve(node.func, _COLOR_MAP)
         if current == _CORE:
             continue
         _tag_func(node.func, _ORIGIN_ATTR, (current or frozenset()) | colors)
@@ -164,7 +188,7 @@ def _read_empties(
     """node -> its typed-empty, for every node whose func carries an `empty` tag."""
     out: Dict[base_types.ComputationNode, Any] = {}
     for node in graph.get_all_nodes(_edges(graph_or_edges)):
-        value = getattr(node.func, _EMPTY_ATTR, _UNSET)
+        value = _resolve(node.func, _EMPTY_MAP, _UNSET)
         if value is not _UNSET:
             out[node] = value
     return out
@@ -204,7 +228,7 @@ def _read_colors(
     """node -> its color set, for every colored node (core / untagged omitted)."""
     out = {}
     for node in graph.get_all_nodes(_edges(graph_or_edges)):
-        tag = getattr(node.func, _ORIGIN_ATTR, None)
+        tag = _resolve(node.func, _COLOR_MAP)
         if tag and tag != _CORE:
             out[node] = tag
     return out

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -124,7 +124,14 @@ def tag_empty(empty: Any, subgraph: base_types.GraphType) -> base_types.GraphTyp
     intolerant frontier consuming that sink can be satisfied without it when the
     producer is pruned. Standalone analogue of `add_colors(..., empty=...)` for
     when the empty is attached independently of coloring."""
-    for sink in _sinks(subgraph):
+    sinks = _sinks(subgraph)
+    if isinstance(subgraph, base_types.GraphType):
+        # A declared sink with a future self-edge (e.g. a memory/remember node) is a
+        # SOURCE of its own future edge, so leaf detection misses it -- stamp it too.
+        sink = subgraph.sink
+        if sink is not None and not sink.is_terminal and not _is_source(sink):
+            sinks = sinks | {sink}
+    for sink in sinks:
         _tag_func(sink.func, _EMPTY_ATTR, empty)
     return subgraph
 
@@ -147,6 +154,25 @@ def _pin_core_func(func):
     # too. Returns the func. No-op on un-taggable (builtin/C) callables.
     _tag_func(func, _ORIGIN_ATTR, _CORE)
     return func
+
+
+def pin_core_excluding(subgraph, excluded) -> base_types.GraphType:
+    """`pin_core`, scoped: pin every colorable node of `subgraph` CORE except the
+    nodes of the `excluded` subgraphs -- per-color channels composed into shared
+    machinery (e.g. a skill's effect channel feeding a shared ack aggregation) that
+    must stay colored/prunable. Pinning them instead makes them ALWAYS-RUN, where
+    they evaluate their pruned inputs' boundary defaults as domain truth (the
+    false-latch class). Pair each excluded channel with a typed-empty
+    (`tag_empty`) so the shared machinery is satisfied when it prunes. Returns
+    `subgraph`."""
+    excluded_nodes = (
+        frozenset().union(*(_colorable_nodes(g) for g in excluded))
+        if excluded
+        else frozenset()
+    )
+    for node in _colorable_nodes(subgraph) - excluded_nodes:
+        _pin_core_func(node.func)
+    return subgraph
 
 
 def pin_core(subgraph_or_callable):
@@ -372,11 +398,17 @@ def _intolerant_frontiers(edges, node_to_colors, empties):
             yield producer, consumer, producer in empties
 
 
-def _must_run_closure(edges, seeds):
+def _must_run_closure(edges, seeds, empties):
     """`seeds` plus their intolerant input cone: backward from each seed, a node's
     producers are pulled in only while the node is an INTOLERANT consumer (needs all
     its args). Stop at tolerant consumers (first_sink / terminals) -- their inputs may
-    prune, so the cone ends there. Tolerance-aware, tag-driven analogue of a data-flow
+    prune, so the cone ends there -- and at EMPTY-TAGGED producers: a producer with a
+    typed-empty satisfies even a forced consumer via its boundary default, so it (and
+    its whole input cone) stays prunable. Without that stop, a single untagged
+    frontier anywhere downstream forces entire skill channels always-on THROUGH their
+    empty-tagged interior nodes -- and an always-run memory/decision node then ticks
+    on its pruned inputs' boundary defaults, committing garbage to cross-turn state
+    (the false-latch class). Tolerance-aware, tag-driven analogue of a data-flow
     core-reach: everything reached must run every turn."""
     incoming: Dict = collections.defaultdict(list)
     for edge in edges:
@@ -391,7 +423,7 @@ def _must_run_closure(edges, seeds):
         seen.add(node)
         if _is_tolerant_consumer(node):
             continue  # tolerant: its inputs may prune, don't pull them in
-        stack.extend(incoming.get(node, ()))
+        stack.extend(p for p in incoming.get(node, ()) if p not in empties)
     return seen
 
 
@@ -450,8 +482,9 @@ def build_node_activation_from_edges(
             ),
             missing=untagged,
         )
-    # Force always-on: untagged intolerant-frontier producers + their intolerant cone.
-    for node in _must_run_closure(edges, {p for p, _ in untagged}):
+    # Force always-on: untagged intolerant-frontier producers + their intolerant cone
+    # (stopping at empty-tagged producers, which stay prunable behind their default).
+    for node in _must_run_closure(edges, {p for p, _ in untagged}, empties):
         node_to_colors.pop(node, None)
 
     boundary_defaults: Dict[base_types.ComputationNode, Any] = {}

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -36,19 +36,38 @@ _UNSET = object()
 # Node selection: sources are caller-seeded and terminals are sinks; neither is
 # ever skipped, so neither is colorable.
 # --------------------------------------------------------------------------- #
+def _edges(graph_or_edges) -> FrozenSet[base_types.ComputationEdge]:
+    # Every public entry point accepts either a `GraphType` or a bare edge
+    # collection; internals below always work on edges.
+    return (
+        graph_or_edges.edges
+        if isinstance(graph_or_edges, base_types.GraphType)
+        else graph_or_edges
+    )
+
+
 def _is_source(node: base_types.ComputationNode) -> bool:
     return getattr(node.func, "__name__", "").startswith("source:")
 
 
-def _colorable_nodes(edges: base_types.GraphType) -> FrozenSet[base_types.ComputationNode]:
+def _colorable_nodes(graph_or_edges) -> FrozenSet[base_types.ComputationNode]:
+    edges = _edges(graph_or_edges)
     return frozenset(
         n for n in graph.get_all_nodes(edges) if not n.is_terminal and not _is_source(n)
     )
 
 
-def _sinks(edges: base_types.GraphType) -> FrozenSet[base_types.ComputationNode]:
+def _leaves(edges) -> FrozenSet[base_types.ComputationNode]:
+    all_sources = frozenset(
+        source for edge in edges for source in base_types.edge_sources(edge)
+    )
+    return graph.get_all_nodes(edges) - all_sources
+
+
+def _sinks(graph_or_edges) -> FrozenSet[base_types.ComputationNode]:
+    edges = _edges(graph_or_edges)
     return frozenset(
-        n for n in graph.get_leaves(edges) if not n.is_terminal and not _is_source(n)
+        n for n in _leaves(edges) if not n.is_terminal and not _is_source(n)
     )
 
 
@@ -109,11 +128,11 @@ def tag_empty(empty: Any, subgraph: base_types.GraphType) -> base_types.GraphTyp
 
 
 def _read_empties(
-    edges: base_types.GraphType,
+    graph_or_edges,
 ) -> Dict[base_types.ComputationNode, Any]:
     """node -> its typed-empty, for every node whose func carries an `empty` tag."""
     out: Dict[base_types.ComputationNode, Any] = {}
-    for node in graph.get_all_nodes(edges):
+    for node in graph.get_all_nodes(_edges(graph_or_edges)):
         value = getattr(node.func, _EMPTY_ATTR, _UNSET)
         if value is not _UNSET:
             out[node] = value
@@ -138,7 +157,9 @@ def pin_core(subgraph_or_callable):
     closure -> single color -> pruned on every other skill's turn, starving core
     flows. The tag rides func.__dict__ through duplication. Returns the argument
     unchanged."""
-    if not isinstance(subgraph_or_callable, (tuple, list, set, frozenset)):
+    if not isinstance(
+        subgraph_or_callable, (base_types.GraphType, tuple, list, set, frozenset)
+    ):
         _pin_core_func(subgraph_or_callable)
         return subgraph_or_callable
     for node in _colorable_nodes(subgraph_or_callable):
@@ -147,11 +168,11 @@ def pin_core(subgraph_or_callable):
 
 
 def _read_colors(
-    edges: base_types.GraphType,
+    graph_or_edges,
 ) -> Mapping[base_types.ComputationNode, FrozenSet]:
     """node -> its color set, for every colored node (core / untagged omitted)."""
     out = {}
-    for node in graph.get_all_nodes(edges):
+    for node in graph.get_all_nodes(_edges(graph_or_edges)):
         tag = getattr(node.func, _ORIGIN_ATTR, None)
         if tag and tag != _CORE:
             out[node] = tag
@@ -186,7 +207,7 @@ def observer(result: base_types.GraphType, inner: Callable) -> base_types.GraphT
     diagnostics / an optional caller-built must-tick latch, and the pin is defensive.
     Use for any domain combinator that compares-or-accumulates across turns."""
     _mark_observer(inner)
-    for node in graph.get_all_nodes(result):
+    for node in graph.get_all_nodes(_edges(result)):
         if getattr(node.func, "__name__", "") == "when_memory_unavailable":
             _pin_core_func(node.func)
     return result
@@ -236,10 +257,12 @@ def latch(
     self_edge = composers.compose_left_future(
         carry_forward, carry_forward, "previous", default
     )
-    g = base_types.merge_graphs(
+    latched_graph = composers.compose_left_unary(carry_forward, latched)
+    g = graph.merge_graphs(
         composers.compose_dict(carry_forward, {"current": guarded_current}),
         self_edge,
-        composers.compose_left_unary(carry_forward, latched),
+        latched_graph,
+        sink_node_or_graph=latched_graph,
     )
     # Pin the latch's own machinery CORE (carry_forward + the when_memory_unavailable
     # default node + the guard's first_sink/fallback + the pass-through) -- shared
@@ -251,7 +274,7 @@ def latch(
     _pin_core_func(latched)
     current_nodes = (
         _colorable_nodes(current)
-        if isinstance(current, (tuple, frozenset, set))
+        if isinstance(current, (base_types.GraphType, tuple, frozenset, set))
         else frozenset()
     )
     for node in _colorable_nodes(guarded_current) - current_nodes:
@@ -349,7 +372,7 @@ def _must_run_closure(edges, seeds):
 
 
 def build_node_activation_from_edges(
-    edges: base_types.GraphType, *, strict: bool = False
+    graph_or_edges, *, strict: bool = False
 ) -> run.NodeActivation:
     """Derive `run.NodeActivation` from an assembled, possibly-duplicated graph using
     only the author tags carried on the node funcs:
@@ -384,6 +407,7 @@ def build_node_activation_from_edges(
     `strict=True` instead RAISES `BoundaryDefaultRequired` listing the untagged
     intolerant frontiers (an audit of what falls back to always-on) rather than forcing
     them core."""
+    edges = _edges(graph_or_edges)
     colors = _read_colors(edges)
     node_to_colors = {n: c for n, c in colors.items() if len(c) == 1}
     empties = _read_empties(edges)

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -13,9 +13,8 @@ subgraph, empty=...)` stamps `func.__cg_origin__` (+ an optional `__cg_empty__`)
 absorbing `_CORE` marker. `build_node_activation_from_edges` then recovers the whole
 `run.NodeActivation` from the final graph's tags: the SINGLE-COLOR RULE (>=2 colors =
 shared = always-on), a tolerance-aware must-run closure, and combiner-aware boundary
-defaults from the `empty` tags. `emit_active_colors` declares the node that sets the
-active colors; `latch` makes a value survive the turn its producer prunes (pinning its
-own machinery core).
+defaults from the `empty` tags. `latch` makes a value survive the turn its producer
+prunes (pinning its own machinery core).
 
 The engine stays domain-agnostic: colors are opaque tokens; nothing here knows
 skills / routes / effects.
@@ -318,22 +317,15 @@ def _must_run_closure(edges, seeds):
 
 
 def build_node_activation_from_edges(
-    edges: base_types.GraphType, *, strict: bool = False, prune_shared: bool = False
+    edges: base_types.GraphType, *, strict: bool = False
 ) -> run.NodeActivation:
     """Derive `run.NodeActivation` from an assembled, possibly-duplicated graph using
     only the author tags carried on the node funcs:
 
       * COLORS  (`_read_colors`)  -- the per-node color sets.
-      * SINGLE-COLOR RULE -- by default only nodes with EXACTLY ONE color are colored
-        (prunable); a node with >=2 colors is SHARED and always-runs (an authoring-time
-        proxy for "shared -> feeds core"), an untagged node is CORE. With
-        `prune_shared=True` a SHARED node is ALSO prunable -- it carries its full color
-        SET, so the runner skips it only when ALL its colors are inactive (it still runs
-        on any owning skill's turn). This is safe because the must-run closure below
-        independently forces always-on any shared node that actually feeds an intolerant
-        core frontier; a shared node that only flows into skill work then prunes when
-        none of its skills is active. (Test before trusting -- run the danger diagnostic
-        + an e2e diff.)
+      * SINGLE-COLOR RULE -- only nodes with EXACTLY ONE color are colored (prunable);
+        a node with >=2 colors is SHARED and always-runs (an authoring-time proxy for
+        "shared -> feeds core"), an untagged node is CORE.
       * MUST-RUN CLOSURE -- every colored producer at an INTOLERANT frontier with NO
         `empty` tag, PLUS its intolerant input cone, is forced always-on: an always-on
         intolerant consumer needs its REAL inputs (it has no default to substitute).
@@ -359,11 +351,9 @@ def build_node_activation_from_edges(
 
     `strict=True` instead RAISES `BoundaryDefaultRequired` listing the untagged
     intolerant frontiers (an audit of what falls back to always-on) rather than forcing
-    them core. Mirrors `build_node_activation` (the Tier-1 path) sourced from tags."""
+    them core."""
     colors = _read_colors(edges)
-    node_to_colors = (
-        dict(colors) if prune_shared else {n: c for n, c in colors.items() if len(c) == 1}
-    )
+    node_to_colors = {n: c for n, c in colors.items() if len(c) == 1}
     empties = _read_empties(edges)
 
     untagged = [

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -26,27 +26,23 @@ from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional
 
 from computation_graph import base_types, composers, graph, run
 
-# The three "tags" are kept in PROCESS-LOCAL MAPS keyed by the func object, NOT on
-# `func.__dict__`. `_ORIGIN_ATTR` etc. survive only as the map selectors below.
 _ORIGIN_ATTR = "__cg_origin__"
 _EMPTY_ATTR = "__cg_empty__"
 _OBSERVER_ATTR = "__cg_observer__"
 _UNSET = object()
 
-# Colors used to be stamped on the process-global `func.__dict__`. That leaked across
-# bot builds (shared-by-reference funcs -- generic combinators, module-level slot defs
-# -- carried an earlier build's colors into a later one), and clearing the tags per
-# build was ruinously slow under the test runner, which instruments every `__dict__`
-# mutation for dependency tracking (tens of thousands of mutations per build).
-#
-# Instead we keep the tags in module-level MAPS keyed by func. `reset_colors` drops
-# them in O(1) with ZERO per-func mutation, so each build starts clean and nothing
-# touches the shared func objects. Provenance still survives `duplicate_function`:
-# functools.wraps sets `inner.__wrapped__ = original`, so `_resolve` walks the
-# __wrapped__ chain to recover a duplicate's tag from the original it was copied from.
-_COLOR_MAP: Dict = {}  # func -> frozenset(colors)  |  _CORE
-_EMPTY_MAP: Dict = {}  # func -> typed-empty value
-_OBSERVER_MAP: Dict = {}  # func -> True
+# Each tag is stamped on `func.__dict__` as a `(generation, value)` PAIR. It rides
+# `duplicate_function` for free (functools.wraps copies __dict__), so provenance is
+# recoverable from the assembled graph -- by tag, not by shape. `reset_colors` bumps a
+# module-global build generation and readers IGNORE any tag from an older generation, so
+# an earlier build's colors on a shared-by-reference func (generic combinators,
+# module-level slot defs) are invisible to a later build -- per-build isolation with NO
+# per-func mutation on reset (just one int bump). This matters because the test runner
+# instruments func.__dict__ mutations for dependency tracking: TAGGING is one setattr
+# per tag (unavoidable, cheap), but WIPING the tags per build (the previous approach) was
+# tens of thousands of mutations per build and blew the suite past its timeout. Bumping
+# one int is free.
+_BUILD_GEN = [0]  # current build generation; `reset_colors` increments it
 
 
 # --------------------------------------------------------------------------- #
@@ -89,63 +85,59 @@ def _sinks(graph_or_edges) -> FrozenSet[base_types.ComputationNode]:
 
 
 # --------------------------------------------------------------------------- #
-# The color tag rides the func's `__dict__`, so it survives `duplicate_function`
-# (functools.wraps copies `__dict__`) and is recoverable from the assembled graph.
-# The tag is a FROZENSET of opaque color tokens (colors UNION when more than one
-# author tags the same func -- a building block shared by reference among skills A
-# and B ends up {A, B}), OR the absorbing sentinel `_CORE` meaning "never color this"
-# (a core/shared func, pinned at its authoring site, stays uncolored even when a
-# skill's sweep later passes over a duplicated copy of it).
+# A tag is stamped on `func.__dict__` as `(generation, value)`, so it rides
+# `duplicate_function` (functools.wraps copies `__dict__`) and is recoverable from the
+# assembled graph. `value` is a FROZENSET of opaque color tokens (colors UNION when
+# more than one author tags the same func -- a building block shared by reference among
+# skills A and B ends up {A, B}), OR the absorbing sentinel `_CORE` meaning "never color
+# this" (a core/shared func stays uncolored even when a skill's sweep passes over a
+# duplicated copy of it). A CORE pin is stamped with `_PERMANENT` so it is valid in
+# EVERY build (core is core everywhere -- always-run, safe); every other tag is valid
+# only in the build generation it was stamped in, so `reset_colors` (a generation bump)
+# invalidates it without touching the func.
 # --------------------------------------------------------------------------- #
 _CORE = "\x00cg-core"  # absorbing marker; not a usable color token
+_PERMANENT = -1  # generation sentinel: valid in every build (used for CORE pins)
 
 
-_ATTR_TO_MAP = {
-    _ORIGIN_ATTR: _COLOR_MAP,
-    _EMPTY_ATTR: _EMPTY_MAP,
-    _OBSERVER_ATTR: _OBSERVER_MAP,
-}
-
-
-def _tag_func(func, attr: str, value) -> None:
-    # Record `value` for `func` in the map selected by `attr`. Keyed by the func object
-    # (no `func.__dict__` mutation). No-op on an unhashable callable -> it stays
-    # untracked, which the readers treat as core (same as the old un-taggable path).
+def _tag_func(func, attr: str, value, *, permanent: bool = False) -> None:
+    # Stamp `(generation, value)` onto the func's __dict__ so it rides
+    # `duplicate_function` (functools.wraps copies __dict__). `permanent=True` (CORE
+    # pins) uses a generation that matches every build, so the pin survives resets. No-op
+    # on an un-taggable builtin / C callable -> it stays tag-less, which readers treat as
+    # core.
+    gen = _PERMANENT if permanent else _BUILD_GEN[0]
     try:
-        _ATTR_TO_MAP[attr][func] = value
-    except TypeError:
+        setattr(func, attr, (gen, value))
+    except (AttributeError, TypeError):
         pass
 
 
-def _resolve(func, mapping, default=None):
-    # A duplicate isn't in the map, but functools.wraps set its `__wrapped__` to the
-    # func it was copied from -- walk that chain to recover the tag the original carried
-    # (this is how tags "survive duplication" now that they live off `func.__dict__`).
-    for _ in range(64):  # depth guard against a pathological __wrapped__ cycle
-        try:
-            if func in mapping:
-                return mapping[func]
-        except TypeError:  # unhashable -> untracked
-            return default
-        func = getattr(func, "__wrapped__", None)
-        if func is None:
-            break
+def _tag_get(func, attr: str, default=None):
+    # Read a tag back, honoring the build generation: a tag stamped in an EARLIER build
+    # (gen != current and not _PERMANENT) is invisible -> treated as absent. Cheap C-level
+    # getattr + tuple unpack; called per node during `build_node_activation`.
+    pair = getattr(func, attr, None)
+    if pair is None:
+        return default
+    gen, value = pair
+    if gen == _PERMANENT or gen == _BUILD_GEN[0]:
+        return value
     return default
 
 
 def reset_colors() -> None:
-    """Drop every color/empty/observer tag stamped since the last reset. Call ONCE at
-    the START of each bot build -- before any `add_colors` / `pin_core` / `observer`
+    """Invalidate every color/empty/observer tag stamped since the last reset. Call ONCE
+    at the START of each bot build -- before any `add_colors` / `pin_core` / `observer`
     sweep and before graph construction -- so tags stamped by an EARLIER build cannot
     leak into a LATER build that reuses the same shared-by-reference funcs (generic
-    combinators, module-level slot defs). O(1) and mutation-free (the tags live in
-    module maps, not on the funcs), so it is cheap even under a test runner that
-    instruments `__dict__` writes. Idempotent; a build that never colored is
-    unaffected. Deliberately NOT called mid-build: a multi-skill bot compiles many
-    subgraphs and clearing between them would leave the later compiles uncolored."""
-    _COLOR_MAP.clear()
-    _EMPTY_MAP.clear()
-    _OBSERVER_MAP.clear()
+    combinators, module-level slot defs). Bumps the build generation: O(1) and
+    MUTATION-FREE (it touches no func), so it is cheap even under a test runner that
+    instruments `__dict__` writes. CORE pins are `_PERMANENT` and survive (core is core
+    in every build). Idempotent; a build that never colored is unaffected. Deliberately
+    NOT called mid-build: a multi-skill bot compiles many subgraphs and bumping between
+    them would make the later compiles read as uncolored."""
+    _BUILD_GEN[0] += 1
 
 
 def add_colors(
@@ -163,7 +155,7 @@ def add_colors(
     make_first sinks, and terminals -- which the runner merges via make_or) never
     consult it, so only the genuinely intolerant frontier needs an `empty`."""
     for node in _colorable_nodes(subgraph):
-        current = _resolve(node.func, _COLOR_MAP)
+        current = _tag_get(node.func, _ORIGIN_ATTR)
         if current == _CORE:
             continue
         _tag_func(node.func, _ORIGIN_ATTR, (current or frozenset()) | colors)
@@ -188,7 +180,7 @@ def _read_empties(
     """node -> its typed-empty, for every node whose func carries an `empty` tag."""
     out: Dict[base_types.ComputationNode, Any] = {}
     for node in graph.get_all_nodes(_edges(graph_or_edges)):
-        value = _resolve(node.func, _EMPTY_MAP, _UNSET)
+        value = _tag_get(node.func, _EMPTY_ATTR, _UNSET)
         if value is not _UNSET:
             out[node] = value
     return out
@@ -197,8 +189,9 @@ def _read_empties(
 def _pin_core_func(func):
     # Pin a single callable CORE (absorbing -- a later color sweep leaves it alone).
     # The CORE tag rides func.__dict__ through duplicate_function, so copies stay core
-    # too. Returns the func. No-op on un-taggable (builtin/C) callables.
-    _tag_func(func, _ORIGIN_ATTR, _CORE)
+    # too. Stamped `_PERMANENT` (survives `reset_colors`): a core func is core in every
+    # build. Returns the func. No-op on un-taggable (builtin/C) callables.
+    _tag_func(func, _ORIGIN_ATTR, _CORE, permanent=True)
     return func
 
 
@@ -228,7 +221,7 @@ def _read_colors(
     """node -> its color set, for every colored node (core / untagged omitted)."""
     out = {}
     for node in graph.get_all_nodes(_edges(graph_or_edges)):
-        tag = _resolve(node.func, _COLOR_MAP)
+        tag = _tag_get(node.func, _ORIGIN_ATTR)
         if tag and tag != _CORE:
             out[node] = tag
     return out

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -129,6 +129,21 @@ def _pin_core_func(func):
     return func
 
 
+def pin_core(subgraph: base_types.GraphType) -> base_types.GraphType:
+    """Pin every colorable node of `subgraph` CORE (absorbing): a later `add_colors`
+    sweep passing over these funcs -- or over any DUPLICATE of them -- leaves them
+    uncolored, so they always run. Use at the AUTHORING SITE of shared machinery
+    that skills later compose into their own channels (routing state, shared event
+    chains): without the pin, each per-skill duplicate ends up inside exactly one
+    skill's closure -> single color -> pruned on every other skill's turn, starving
+    core flows (e.g. a routing event chain that must fire on a turn whose active
+    color is a different skill). The tag rides func.__dict__ through duplication.
+    Returns the graph unchanged."""
+    for node in _colorable_nodes(subgraph):
+        _pin_core_func(node.func)
+    return subgraph
+
+
 def _read_colors(
     edges: base_types.GraphType,
 ) -> Mapping[base_types.ComputationNode, FrozenSet]:

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -3,13 +3,13 @@ while you BUILD the graph, and derive the runner's `run.NodeActivation` from it 
 instead of reconstructing colors from a post-assembly graph's shape (`_core_reach`).
 
 The runner already speaks coloring (`run.NodeActivation`, `run.ChangeActiveColors`,
-`run.to_callable_with_node_activation`); this module produces that spec.
+`run.to_callable_with_coloring`); this module produces that spec.
 
 Colors are stamped as TAGS on the func's `__dict__`, so they ride through
 `duplicate_function` for free (functools.wraps copies `__dict__`) and survive any
 amount of duplication -- provenance by tag, not by shape. `add_colors(COLORS,
 subgraph, empty=...)` stamps `func.__cg_origin__` (+ an optional `__cg_empty__`),
-`mark_observer` / `observer` stamp `__cg_observer__`, and `pin_core*` stamps the
+`observer` stamps `__cg_observer__`, and `_pin_core_func` stamps the
 absorbing `_CORE` marker. `build_node_activation_from_edges` then recovers the whole
 `run.NodeActivation` from the final graph's tags: the SINGLE-COLOR RULE (>=2 colors =
 shared = always-on), a tolerance-aware must-run closure, and combiner-aware boundary
@@ -65,11 +65,14 @@ def _sinks(edges: base_types.GraphType) -> FrozenSet[base_types.ComputationNode]
 _CORE = "\x00cg-core"  # absorbing marker; not a usable color token
 
 
-def _set_tag(node: base_types.ComputationNode, value) -> None:
+def _tag_func(func, attr: str, value) -> None:
+    # The one guarded stamp: write `attr = value` onto the func's __dict__ so it rides
+    # `duplicate_function` (functools.wraps copies __dict__). No-op on an un-taggable
+    # builtin / C callable -> it stays tag-less, which the readers treat as core.
     try:
-        setattr(node.func, _ORIGIN_ATTR, value)
+        setattr(func, attr, value)
     except (AttributeError, TypeError):
-        pass  # builtin / C func -> untaggable -> stays tag-less (treated as core)
+        pass
 
 
 def add_colors(
@@ -90,17 +93,10 @@ def add_colors(
         current = getattr(node.func, _ORIGIN_ATTR, None)
         if current == _CORE:
             continue
-        _set_tag(node, (current or frozenset()) | colors)
+        _tag_func(node.func, _ORIGIN_ATTR, (current or frozenset()) | colors)
     if empty is not _UNSET:
         tag_empty(empty, subgraph)
     return subgraph
-
-
-def _set_empty(node: base_types.ComputationNode, value) -> None:
-    try:
-        setattr(node.func, _EMPTY_ATTR, value)
-    except (AttributeError, TypeError):
-        pass  # builtin / C func -> untaggable
 
 
 def tag_empty(empty: Any, subgraph: base_types.GraphType) -> base_types.GraphType:
@@ -109,11 +105,11 @@ def tag_empty(empty: Any, subgraph: base_types.GraphType) -> base_types.GraphTyp
     producer is pruned. Standalone analogue of `add_colors(..., empty=...)` for
     when the empty is attached independently of coloring."""
     for sink in _sinks(subgraph):
-        _set_empty(sink, empty)
+        _tag_func(sink.func, _EMPTY_ATTR, empty)
     return subgraph
 
 
-def read_empties(
+def _read_empties(
     edges: base_types.GraphType,
 ) -> Dict[base_types.ComputationNode, Any]:
     """node -> its typed-empty, for every node whose func carries an `empty` tag."""
@@ -125,18 +121,15 @@ def read_empties(
     return out
 
 
-def pin_core_func(func):
-    """Pin a single callable CORE (the func-level analogue of `pin_core`). The CORE
-    tag rides func.__dict__ through duplicate_function, so copies stay core too.
-    Returns the func. No-op on un-taggable (builtin/C) callables."""
-    try:
-        setattr(func, _ORIGIN_ATTR, _CORE)
-    except (AttributeError, TypeError):
-        pass
+def _pin_core_func(func):
+    # Pin a single callable CORE (absorbing -- a later color sweep leaves it alone).
+    # The CORE tag rides func.__dict__ through duplicate_function, so copies stay core
+    # too. Returns the func. No-op on un-taggable (builtin/C) callables.
+    _tag_func(func, _ORIGIN_ATTR, _CORE)
     return func
 
 
-def read_colors(
+def _read_colors(
     edges: base_types.GraphType,
 ) -> Mapping[base_types.ComputationNode, FrozenSet]:
     """node -> its color set, for every colored node (core / untagged omitted)."""
@@ -150,8 +143,8 @@ def read_colors(
 
 # --------------------------------------------------------------------------- #
 # Observers: nodes that compare-or-accumulate across turns (lag / changed / ever /
-# accumulate, and any domain combinator that does the same). `mark_observer` tags
-# them and `observer` also pins their future-state machinery core. NOTE:
+# accumulate, and any domain combinator that does the same). `observer` tags them
+# (via `_mark_observer`) and also pins their future-state machinery core. NOTE:
 # `build_node_activation_from_edges` does NOT exempt observers -- a skill-private
 # observer prunes WITH its skill (it feeds the tolerant EVENT path so an inactive
 # skill emits no event, and its accumulated state survives the pruned turn via the
@@ -161,27 +154,24 @@ def read_colors(
 # observer's input; the machinery pin is defensive (a same-color when_memory_unavailable
 # wouldn't create a frontier anyway).
 # --------------------------------------------------------------------------- #
-def mark_observer(func):
-    """Mark a node func as a must-tick observer (rides `func.__dict__` through
-    duplication). Returns the func."""
-    try:
-        setattr(func, _OBSERVER_ATTR, True)
-    except (AttributeError, TypeError):
-        pass
+def _mark_observer(func):
+    # Mark a node func as a must-tick observer (rides `func.__dict__` through
+    # duplication). Returns the func. Internal: applied by `observer` below.
+    _tag_func(func, _OBSERVER_ATTR, True)
     return func
 
 
 def observer(result: base_types.GraphType, inner: Callable) -> base_types.GraphType:
     """Declare `inner` (the across-turns node of the observer combinator `result`) an
-    observer: `mark_observer` it and pin its own future-state machinery CORE (the
+    observer: `_mark_observer` it and pin its own future-state machinery CORE (the
     `when_memory_unavailable` default node its future self-edge creates). See the note
     above -- observers are NOT exempted by the activation builder; the mark drives
     diagnostics / an optional caller-built must-tick latch, and the pin is defensive.
     Use for any domain combinator that compares-or-accumulates across turns."""
-    mark_observer(inner)
+    _mark_observer(inner)
     for node in graph.get_all_nodes(result):
         if getattr(node.func, "__name__", "") == "when_memory_unavailable":
-            pin_core_func(node.func)
+            _pin_core_func(node.func)
     return result
 
 
@@ -227,8 +217,8 @@ def latch(
     # default node + the pass-through) -- shared carry-forward infra that must run every
     # turn; `current`'s subgraph stays colored/prunable.
     for node in _colorable_nodes(self_edge):
-        _set_tag(node, _CORE)
-    pin_core_func(latched)
+        _pin_core_func(node.func)
+    _pin_core_func(latched)
     return g
 
 
@@ -318,7 +308,7 @@ def build_node_activation_from_edges(
     """Derive `run.NodeActivation` from an assembled, possibly-duplicated graph using
     only the author tags carried on the node funcs:
 
-      * COLORS  (`read_colors`)  -- the per-node color sets.
+      * COLORS  (`_read_colors`)  -- the per-node color sets.
       * SINGLE-COLOR RULE -- by default only nodes with EXACTLY ONE color are colored
         (prunable); a node with >=2 colors is SHARED and always-runs (an authoring-time
         proxy for "shared -> feeds core"), an untagged node is CORE. With
@@ -349,17 +339,17 @@ def build_node_activation_from_edges(
     intolerant core consumer is caught by the generic closure above, like any producer.
     (Forcing observer cones always-on was measured to drag in ~the whole graph, since
     observers transitively depend on nearly everything -- it defeats pruning entirely.)
-    `mark_observer` / `observer_nodes` remain available for a caller that needs an
-    explicit must-tick latch on an observer's input.
+    The `__cg_observer__` mark (stamped by `observer`) is available to a caller that
+    wants to build an explicit must-tick latch on an observer's input.
 
     `strict=True` instead RAISES `BoundaryDefaultRequired` listing the untagged
     intolerant frontiers (an audit of what falls back to always-on) rather than forcing
     them core. Mirrors `build_node_activation` (the Tier-1 path) sourced from tags."""
-    colors = read_colors(edges)
+    colors = _read_colors(edges)
     node_to_colors = (
         dict(colors) if prune_shared else {n: c for n, c in colors.items() if len(c) == 1}
     )
-    empties = read_empties(edges)
+    empties = _read_empties(edges)
 
     untagged = [
         (p, c) for p, c, defaultable in _intolerant_frontiers(edges, node_to_colors, empties)

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -1,0 +1,388 @@
+"""Authoring-time COLORING composers: declare which nodes belong to which color
+while you BUILD the graph, and derive the runner's `run.NodeActivation` from it --
+instead of reconstructing colors from a post-assembly graph's shape (`_core_reach`).
+
+The runner already speaks coloring (`run.NodeActivation`, `run.ChangeActiveColors`,
+`run.to_callable_with_node_activation`); this module produces that spec.
+
+Colors are stamped as TAGS on the func's `__dict__`, so they ride through
+`duplicate_function` for free (functools.wraps copies `__dict__`) and survive any
+amount of duplication -- provenance by tag, not by shape. `add_colors(COLORS,
+subgraph, empty=...)` stamps `func.__cg_origin__` (+ an optional `__cg_empty__`),
+`mark_observer` / `observer` stamp `__cg_observer__`, and `pin_core*` stamps the
+absorbing `_CORE` marker. `build_node_activation_from_edges` then recovers the whole
+`run.NodeActivation` from the final graph's tags: the SINGLE-COLOR RULE (>=2 colors =
+shared = always-on), a tolerance-aware must-run closure, and combiner-aware boundary
+defaults from the `empty` tags. `emit_active_colors` declares the node that sets the
+active colors; `latch` makes a value survive the turn its producer prunes (pinning its
+own machinery core).
+
+The engine stays domain-agnostic: colors are opaque tokens; nothing here knows
+skills / routes / effects.
+"""
+from __future__ import annotations
+
+import collections
+from typing import Any, Callable, Dict, FrozenSet, Mapping
+
+from computation_graph import base_types, composers, graph, run
+
+_ORIGIN_ATTR = "__cg_origin__"
+_EMPTY_ATTR = "__cg_empty__"
+_OBSERVER_ATTR = "__cg_observer__"
+_UNSET = object()
+
+
+# --------------------------------------------------------------------------- #
+# Node selection: sources are caller-seeded and terminals are sinks; neither is
+# ever skipped, so neither is colorable.
+# --------------------------------------------------------------------------- #
+def _is_source(node: base_types.ComputationNode) -> bool:
+    return getattr(node.func, "__name__", "").startswith("source:")
+
+
+def _colorable_nodes(edges: base_types.GraphType) -> FrozenSet[base_types.ComputationNode]:
+    return frozenset(
+        n for n in graph.get_all_nodes(edges) if not n.is_terminal and not _is_source(n)
+    )
+
+
+def _sinks(edges: base_types.GraphType) -> FrozenSet[base_types.ComputationNode]:
+    return frozenset(
+        n for n in graph.get_leaves(edges) if not n.is_terminal and not _is_source(n)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The color tag rides the func's `__dict__`, so it survives `duplicate_function`
+# (functools.wraps copies `__dict__`) and is recoverable from the assembled graph.
+# The tag is a FROZENSET of opaque color tokens (colors UNION when more than one
+# author tags the same func -- a building block shared by reference among skills A
+# and B ends up {A, B}), OR the absorbing sentinel `_CORE` meaning "never color this"
+# (a core/shared func, pinned at its authoring site, stays uncolored even when a
+# skill's sweep later passes over a duplicated copy of it).
+# --------------------------------------------------------------------------- #
+_CORE = "\x00cg-core"  # absorbing marker; not a usable color token
+
+
+def _set_tag(node: base_types.ComputationNode, value) -> None:
+    try:
+        setattr(node.func, _ORIGIN_ATTR, value)
+    except (AttributeError, TypeError):
+        pass  # builtin / C func -> untaggable -> stays tag-less (treated as core)
+
+
+def add_colors(
+    colors: FrozenSet, subgraph: base_types.GraphType, *, empty: Any = _UNSET
+) -> base_types.GraphType:
+    """Union `colors` into every colorable node's tag. A func already pinned core
+    is left untouched (core is absorbing). Returns the graph unchanged (the tag
+    rides each func, so it survives duplication).
+
+    `empty` (optional) is the subgraph's typed-empty output: it is stamped on the
+    sink func(s) so a pruned skill contributes "nothing" at an INTOLERANT frontier
+    (an aggregation / make_and that needs all its args). Like the color tag it rides
+    `func.__dict__` through duplication; `build_node_activation_from_edges` reads it
+    back at each intolerant colored->core frontier. TOLERANT frontiers (make_or /
+    make_first sinks, and terminals -- which the runner merges via make_or) never
+    consult it, so only the genuinely intolerant frontier needs an `empty`."""
+    for node in _colorable_nodes(subgraph):
+        current = getattr(node.func, _ORIGIN_ATTR, None)
+        if current == _CORE:
+            continue
+        _set_tag(node, (current or frozenset()) | colors)
+    if empty is not _UNSET:
+        tag_empty(empty, subgraph)
+    return subgraph
+
+
+def _set_empty(node: base_types.ComputationNode, value) -> None:
+    try:
+        setattr(node.func, _EMPTY_ATTR, value)
+    except (AttributeError, TypeError):
+        pass  # builtin / C func -> untaggable
+
+
+def tag_empty(empty: Any, subgraph: base_types.GraphType) -> base_types.GraphType:
+    """Stamp `empty` (a typed-empty value) on every sink func of `subgraph` so an
+    intolerant frontier consuming that sink can be satisfied without it when the
+    producer is pruned. Standalone analogue of `add_colors(..., empty=...)` for
+    when the empty is attached independently of coloring."""
+    for sink in _sinks(subgraph):
+        _set_empty(sink, empty)
+    return subgraph
+
+
+def read_empties(
+    edges: base_types.GraphType,
+) -> Dict[base_types.ComputationNode, Any]:
+    """node -> its typed-empty, for every node whose func carries an `empty` tag."""
+    out: Dict[base_types.ComputationNode, Any] = {}
+    for node in graph.get_all_nodes(edges):
+        value = getattr(node.func, _EMPTY_ATTR, _UNSET)
+        if value is not _UNSET:
+            out[node] = value
+    return out
+
+
+def pin_core_func(func):
+    """Pin a single callable CORE (the func-level analogue of `pin_core`). The CORE
+    tag rides func.__dict__ through duplicate_function, so copies stay core too.
+    Returns the func. No-op on un-taggable (builtin/C) callables."""
+    try:
+        setattr(func, _ORIGIN_ATTR, _CORE)
+    except (AttributeError, TypeError):
+        pass
+    return func
+
+
+def read_colors(
+    edges: base_types.GraphType,
+) -> Mapping[base_types.ComputationNode, FrozenSet]:
+    """node -> its color set, for every colored node (core / untagged omitted)."""
+    out = {}
+    for node in graph.get_all_nodes(edges):
+        tag = getattr(node.func, _ORIGIN_ATTR, None)
+        if tag and tag != _CORE:
+            out[node] = tag
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Observers: nodes that compare-or-accumulate across turns (lag / changed / ever /
+# accumulate, and any domain combinator that does the same). `mark_observer` tags
+# them and `observer` also pins their future-state machinery core. NOTE:
+# `build_node_activation_from_edges` does NOT exempt observers -- a skill-private
+# observer prunes WITH its skill (it feeds the tolerant EVENT path so an inactive
+# skill emits no event, and its accumulated state survives the pruned turn via the
+# reducer's {**prev} latch on its future self-edge). Forcing observer cones always-on
+# was measured to drag in ~the whole graph. The mark therefore drives diagnostics and
+# is available for a caller that wants to build an explicit must-tick latch on an
+# observer's input; the machinery pin is defensive (a same-color when_memory_unavailable
+# wouldn't create a frontier anyway).
+# --------------------------------------------------------------------------- #
+def mark_observer(func):
+    """Mark a node func as a must-tick observer (rides `func.__dict__` through
+    duplication). Returns the func."""
+    try:
+        setattr(func, _OBSERVER_ATTR, True)
+    except (AttributeError, TypeError):
+        pass
+    return func
+
+
+def observer(result: base_types.GraphType, inner: Callable) -> base_types.GraphType:
+    """Declare `inner` (the across-turns node of the observer combinator `result`) an
+    observer: `mark_observer` it and pin its own future-state machinery CORE (the
+    `when_memory_unavailable` default node its future self-edge creates). See the note
+    above -- observers are NOT exempted by the activation builder; the mark drives
+    diagnostics / an optional caller-built must-tick latch, and the pin is defensive.
+    Use for any domain combinator that compares-or-accumulates across turns."""
+    mark_observer(inner)
+    for node in graph.get_all_nodes(result):
+        if getattr(node.func, "__name__", "") == "when_memory_unavailable":
+            pin_core_func(node.func)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# The latch: make a value SURVIVE the turn its producer is pruned (the producing
+# color inactive) without a boundary default. Generalizes nlu's var-bus
+# `_LatchConsumeVariable`. The producer feeds a tolerant frontier (a make_or
+# aggregate / a terminal) so a pruned producer is filtered to "absent"; the latch
+# then returns the value's own PREVIOUS (a future self-edge) instead of the absent
+# default, so it persists across the pruned turn.
+# --------------------------------------------------------------------------- #
+def latch(
+    current: base_types.CallableOrNodeOrGraph,
+    *,
+    present: Callable[[Any], bool],
+    default: Any,
+) -> base_types.GraphType:
+    """Carry `current` forward across turns it is absent. `present(value)` decides
+    whether this turn's value is real (else fall back to `previous`); `default` is
+    the value before any turn has produced one. The latch node + the
+    `when_memory_unavailable` default node its future self-edge creates are pinned
+    CORE (they are shared carry-forward machinery that must run every turn) so the
+    per-color sweep can't mis-color them; `current`'s own subgraph stays
+    colored/prunable. Returns a graph whose sink is the latch -- compose consumers
+    onto it."""
+
+    def carry_forward(current, previous):
+        return current if present(current) else previous
+
+    def latched(value):  # pass-through: a future-edge-FREE sink, so consumers and
+        return value  # `sink_excluding_terminals` resolve cleanly (carry_forward's
+        # own future self-edge would otherwise leave the graph with no plain leaf).
+
+    self_edge = composers.compose_left_future(
+        carry_forward, carry_forward, "previous", default
+    )
+    g = base_types.merge_graphs(
+        composers.compose_dict(carry_forward, {"current": current}),
+        self_edge,
+        composers.compose_left_unary(carry_forward, latched),
+    )
+    # Pin the latch's own machinery CORE (carry_forward + the when_memory_unavailable
+    # default node + the pass-through) -- shared carry-forward infra that must run every
+    # turn; `current`'s subgraph stays colored/prunable.
+    for node in _colorable_nodes(self_edge):
+        _set_tag(node, _CORE)
+    pin_core_func(latched)
+    return g
+
+
+# --------------------------------------------------------------------------- #
+# Derive the runner spec.
+# --------------------------------------------------------------------------- #
+class BoundaryDefaultRequired(Exception):
+    def __init__(self, message, missing=()):
+        super().__init__(message)
+        # [(producer, consumer)] -- the intolerant frontiers lacking a typed-empty,
+        # so callers/diagnostics can categorize them without parsing the message.
+        self.missing = tuple(missing)
+
+
+def _is_tolerant_consumer(node: base_types.ComputationNode) -> bool:
+    # A consumer tolerates a pruned input iff a missing arg does not collapse it:
+    #   * make_or / make_first / make_optional funnel each input into a `first_sink`
+    #     node, which tolerates a missing input by construction;
+    #   * a TERMINAL -- the runner merges all edges into a terminal via `make_or`
+    #     (`run._merge_edges_pointing_to_terminals`), so a pruned producer is filtered
+    #     and the terminal's aggregate just shrinks (this is what lets a var-bus
+    #     exposer prune with no default, latched downstream).
+    return node.is_terminal or getattr(node.func, "__name__", "") == "first_sink"
+
+
+def _needs_default(producer_colors: FrozenSet, consumer_colors) -> bool:
+    # A default is needed iff some active set runs the CONSUMER but skips the PRODUCER:
+    #   * uncolored (core) consumer always runs                -> needed
+    #   * colored consumer with a color the producer lacks     -> needed
+    if consumer_colors is None:
+        return True
+    return bool(consumer_colors - producer_colors)
+
+
+# --------------------------------------------------------------------------- #
+# Derive the runner spec straight from the assembled graph's TAGS (colors / empties /
+# observer marks): the author tags survive duplication on the funcs, so the whole
+# activation is recovered from `edges` alone -- no in-memory ColoredGraph needed.
+# --------------------------------------------------------------------------- #
+def _intolerant_frontiers(edges, node_to_colors, empties):
+    """The colored->(core / other-color) frontiers whose consumer is INTOLERANT (not
+    a first_sink, not a terminal). Yields (producer, consumer, producer_is_defaultable).
+    A producer prunes when its (single) color is inactive; the consumer still runs iff
+    it does not share that color (`_needs_default`) -- that is the frontier the runner
+    must handle, by the producer's `empty` tag if it has one, else by the producer
+    being forced always-on."""
+    for edge in edges:
+        consumer = edge.destination
+        if _is_tolerant_consumer(consumer):
+            continue
+        consumer_colors = node_to_colors.get(consumer)
+        for producer in base_types.edge_sources(edge):
+            producer_colors = node_to_colors.get(producer)
+            if producer_colors is None:
+                continue  # core / shared / observer producer -> never pruned
+            if not _needs_default(producer_colors, consumer_colors):
+                continue  # same color -> prune together
+            yield producer, consumer, producer in empties
+
+
+def _must_run_closure(edges, seeds):
+    """`seeds` plus their intolerant input cone: backward from each seed, a node's
+    producers are pulled in only while the node is an INTOLERANT consumer (needs all
+    its args). Stop at tolerant consumers (first_sink / terminals) -- their inputs may
+    prune, so the cone ends there. Tolerance-aware, tag-driven analogue of a data-flow
+    core-reach: everything reached must run every turn."""
+    incoming: Dict = collections.defaultdict(list)
+    for edge in edges:
+        for producer in base_types.edge_sources(edge):
+            incoming[edge.destination].append(producer)
+    seen: set = set()
+    stack = list(seeds)
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        if _is_tolerant_consumer(node):
+            continue  # tolerant: its inputs may prune, don't pull them in
+        stack.extend(incoming.get(node, ()))
+    return seen
+
+
+def build_node_activation_from_edges(
+    edges: base_types.GraphType, *, strict: bool = False, prune_shared: bool = False
+) -> run.NodeActivation:
+    """Derive `run.NodeActivation` from an assembled, possibly-duplicated graph using
+    only the author tags carried on the node funcs:
+
+      * COLORS  (`read_colors`)  -- the per-node color sets.
+      * SINGLE-COLOR RULE -- by default only nodes with EXACTLY ONE color are colored
+        (prunable); a node with >=2 colors is SHARED and always-runs (an authoring-time
+        proxy for "shared -> feeds core"), an untagged node is CORE. With
+        `prune_shared=True` a SHARED node is ALSO prunable -- it carries its full color
+        SET, so the runner skips it only when ALL its colors are inactive (it still runs
+        on any owning skill's turn). This is safe because the must-run closure below
+        independently forces always-on any shared node that actually feeds an intolerant
+        core frontier; a shared node that only flows into skill work then prunes when
+        none of its skills is active. (Test before trusting -- run the danger diagnostic
+        + an e2e diff.)
+      * MUST-RUN CLOSURE -- every colored producer at an INTOLERANT frontier with NO
+        `empty` tag, PLUS its intolerant input cone, is forced always-on: an always-on
+        intolerant consumer needs its REAL inputs (it has no default to substitute).
+        This is the tolerance-aware, tag-driven reduction of a data-flow core-reach --
+        fully generic (CG owns the tolerance rule). An `empty` tag opts a frontier OUT
+        of the closure (the producer prunes and the runner substitutes the empty) --
+        that is how the caller carves prunable regions (e.g. the effect aggregation)
+        out of always-on core.
+      * BOUNDARY DEFAULTS -- the surviving colored producers at intolerant frontiers,
+        each with its `empty` tag.
+
+    OBSERVERS ARE NOT SPECIAL-CASED. A skill-private observer (`source_changed` / `ever`
+    / `lag` / `accumulate` colored a single skill) prunes WITH its skill: it feeds the
+    tolerant EVENT path (no event for an inactive skill -- correct), and its accumulated
+    state survives the pruned turn for free via the reducer's `{**prev}` latch on its
+    future self-edge (it resumes when the skill reactivates, having merely paused while
+    its skill-private input wasn't being produced). An observer that DOES feed an
+    intolerant core consumer is caught by the generic closure above, like any producer.
+    (Forcing observer cones always-on was measured to drag in ~the whole graph, since
+    observers transitively depend on nearly everything -- it defeats pruning entirely.)
+    `mark_observer` / `observer_nodes` remain available for a caller that needs an
+    explicit must-tick latch on an observer's input.
+
+    `strict=True` instead RAISES `BoundaryDefaultRequired` listing the untagged
+    intolerant frontiers (an audit of what falls back to always-on) rather than forcing
+    them core. Mirrors `build_node_activation` (the Tier-1 path) sourced from tags."""
+    colors = read_colors(edges)
+    node_to_colors = (
+        dict(colors) if prune_shared else {n: c for n, c in colors.items() if len(c) == 1}
+    )
+    empties = read_empties(edges)
+
+    untagged = [
+        (p, c) for p, c, defaultable in _intolerant_frontiers(edges, node_to_colors, empties)
+        if not defaultable
+    ]
+    if strict and untagged:
+        raise BoundaryDefaultRequired(
+            "intolerant colored->core frontier without a typed-empty "
+            "(tag it with add_colors(..., empty=...) / tag_empty):\n"
+            + "\n".join(
+                f"  {p.name} {sorted(node_to_colors[p])} --> {c.name}"
+                for p, c in untagged
+            ),
+            missing=untagged,
+        )
+    # Force always-on: untagged intolerant-frontier producers + their intolerant cone.
+    for node in _must_run_closure(edges, {p for p, _ in untagged}):
+        node_to_colors.pop(node, None)
+
+    boundary_defaults: Dict[base_types.ComputationNode, Any] = {}
+    for producer, _consumer, defaultable in _intolerant_frontiers(
+        edges, node_to_colors, empties
+    ):
+        if defaultable:  # producer survived the closure (had an empty) -> prune w/ it
+            boundary_defaults[producer] = empties[producer]
+    return run.NodeActivation(node_to_colors, boundary_defaults)

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -128,19 +128,22 @@ def _pin_core_func(func):
     return func
 
 
-def pin_core(subgraph: base_types.GraphType) -> base_types.GraphType:
-    """Pin every colorable node of `subgraph` CORE (absorbing): a later `add_colors`
-    sweep passing over these funcs -- or over any DUPLICATE of them -- leaves them
-    uncolored, so they always run. Use at the AUTHORING SITE of shared machinery
-    that skills later compose into their own channels (routing state, shared event
-    chains): without the pin, each per-skill duplicate ends up inside exactly one
-    skill's closure -> single color -> pruned on every other skill's turn, starving
-    core flows (e.g. a routing event chain that must fire on a turn whose active
-    color is a different skill). The tag rides func.__dict__ through duplication.
-    Returns the graph unchanged."""
-    for node in _colorable_nodes(subgraph):
+def pin_core(subgraph_or_callable):
+    """Pin every colorable node of a subgraph -- or a single bare callable -- CORE
+    (absorbing): a later `add_colors` sweep passing over these funcs -- or over any
+    DUPLICATE of them -- leaves them uncolored, so they always run. Use at the
+    AUTHORING SITE of shared machinery that skills later compose into their own
+    channels (routing state, shared event chains, variable-exposure derivations):
+    without the pin, each per-skill duplicate ends up inside exactly one skill's
+    closure -> single color -> pruned on every other skill's turn, starving core
+    flows. The tag rides func.__dict__ through duplication. Returns the argument
+    unchanged."""
+    if not isinstance(subgraph_or_callable, (tuple, list, set, frozenset)):
+        _pin_core_func(subgraph_or_callable)
+        return subgraph_or_callable
+    for node in _colorable_nodes(subgraph_or_callable):
         _pin_core_func(node.func)
-    return subgraph
+    return subgraph_or_callable
 
 
 def _read_colors(

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -222,20 +222,42 @@ def latch(
         return value  # `sink_excluding_terminals` resolve cleanly (carry_forward's
         # own future self-edge would otherwise leave the graph with no plain leaf).
 
+    def latch_default():
+        return default
+
+    # `current` enters through a TOLERANT frontier (make_first + a default
+    # fallback): a pruned producer yields `default` (-> not `present` -> previous)
+    # instead of STARVING the pinned carry_forward. Without this guard, a colored
+    # `current` at the pinned-intolerant frontier is caught by the must-run closure,
+    # which forces its whole input cone always-on -- pruning collapses (measured:
+    # bon_secours prunable 50k -> 26k, greeting 257ms -> 11s). A terminal `current`
+    # (the var-bus consume) is already tolerant; the guard is harmless there.
+    guarded_current = composers.make_first(current, latch_default)
     self_edge = composers.compose_left_future(
         carry_forward, carry_forward, "previous", default
     )
     g = base_types.merge_graphs(
-        composers.compose_dict(carry_forward, {"current": current}),
+        composers.compose_dict(carry_forward, {"current": guarded_current}),
         self_edge,
         composers.compose_left_unary(carry_forward, latched),
     )
     # Pin the latch's own machinery CORE (carry_forward + the when_memory_unavailable
-    # default node + the pass-through) -- shared carry-forward infra that must run every
-    # turn; `current`'s subgraph stays colored/prunable.
+    # default node + the guard's first_sink/fallback + the pass-through) -- shared
+    # carry-forward infra that must run every turn; `current`'s subgraph stays
+    # colored/prunable.
     for node in _colorable_nodes(self_edge):
         _pin_core_func(node.func)
+    _pin_core_func(latch_default)
     _pin_core_func(latched)
+    current_nodes = (
+        _colorable_nodes(current)
+        if isinstance(current, (tuple, frozenset, set))
+        else frozenset()
+    )
+    for node in _colorable_nodes(guarded_current) - current_nodes:
+        if callable(current) and node.func is current:
+            continue
+        _pin_core_func(node.func)
     return g
 
 
@@ -258,7 +280,14 @@ def _is_tolerant_consumer(node: base_types.ComputationNode) -> bool:
     #     (`run._merge_edges_pointing_to_terminals`), so a pruned producer is filtered
     #     and the terminal's aggregate just shrinks (this is what lets a var-bus
     #     exposer prune with no default, latched downstream).
-    return node.is_terminal or getattr(node.func, "__name__", "") == "first_sink"
+    # `duplicate_function` prefixes __name__ with "duplicate of ", so strip it --
+    # a DUPLICATED first_sink is exactly as tolerant as the original (missing this
+    # misclassified duplicated sinks as intolerant and closure-forced their whole
+    # producer cones always-on).
+    name = getattr(node.func, "__name__", "")
+    while name.startswith("duplicate of "):
+        name = name[len("duplicate of ") :]
+    return node.is_terminal or name == "first_sink"
 
 
 def _needs_default(producer_colors: FrozenSet, consumer_colors) -> bool:

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -31,6 +31,16 @@ _EMPTY_ATTR = "__cg_empty__"
 _OBSERVER_ATTR = "__cg_observer__"
 _UNSET = object()
 
+# Every func stamped by `_tag_func` is registered here so `reset_colors` can strip
+# the tags again. Colors live on the process-global `func.__dict__` (so they ride
+# `duplicate_function`), and MANY funcs are shared BY REFERENCE across bot builds
+# (generic gamla combinators, module-level slot/configurable definitions built once
+# at import). Without a reset, a bot built earlier stamps these shared objects and a
+# bot built LATER inherits the foreign colors -> mis-pruning. The registry lets each
+# build start from a clean slate; see `reset_colors`.
+_TAGGED_FUNCS: set = set()
+_TAG_ATTRS = (_ORIGIN_ATTR, _EMPTY_ATTR, _OBSERVER_ATTR)
+
 
 # --------------------------------------------------------------------------- #
 # Node selection: sources are caller-seeded and terminals are sinks; neither is
@@ -87,10 +97,31 @@ def _tag_func(func, attr: str, value) -> None:
     # The one guarded stamp: write `attr = value` onto the func's __dict__ so it rides
     # `duplicate_function` (functools.wraps copies __dict__). No-op on an un-taggable
     # builtin / C callable -> it stays tag-less, which the readers treat as core.
+    # Register the func so `reset_colors` can strip every tag it received at the next
+    # build's start (tags leak across builds on shared-by-reference funcs otherwise).
     try:
         setattr(func, attr, value)
     except (AttributeError, TypeError):
-        pass
+        return
+    _TAGGED_FUNCS.add(func)
+
+
+def reset_colors() -> None:
+    """Strip every color/empty/observer tag stamped since the last reset, and forget
+    the funcs that carried them. Call ONCE at the START of each bot build -- before
+    any `add_colors` / `pin_core` / `observer` sweep and before graph construction --
+    so tags stamped by an EARLIER build cannot leak onto shared-by-reference funcs a
+    LATER build reuses (the process-global-`__dict__` contamination). Idempotent; a
+    build that never colored is unaffected. Deliberately NOT called mid-build: a
+    multi-skill bot compiles many subgraphs and clearing between them would leave the
+    later compiles uncolored."""
+    for func in _TAGGED_FUNCS:
+        for attr in _TAG_ATTRS:
+            try:
+                delattr(func, attr)
+            except AttributeError:
+                pass
+    _TAGGED_FUNCS.clear()
 
 
 def add_colors(

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -22,7 +22,7 @@ skills / routes / effects.
 from __future__ import annotations
 
 import collections
-from typing import Any, Callable, Dict, FrozenSet, Mapping
+from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional
 
 from computation_graph import base_types, composers, graph, run
 
@@ -221,15 +221,33 @@ def observer(result: base_types.GraphType, inner: Callable) -> base_types.GraphT
 # then returns the value's own PREVIOUS (a future self-edge) instead of the absent
 # default, so it persists across the pruned turn.
 # --------------------------------------------------------------------------- #
+class _Pruned:
+    """Sentinel the latch guard yields when `current`'s producer was PRUNED this
+    turn (produced nothing). Distinct from any domain value -- in particular from a
+    domain-level "unknown" a producer that RAN can legitimately return. Private:
+    `carry_forward` translates it before any consumer sees it."""
+
+    def __repr__(self):
+        return "_Pruned()"
+
+
+_PRUNED = _Pruned()
+
+
 def latch(
     current: base_types.CallableOrNodeOrGraph,
     *,
-    present: Callable[[Any], bool],
+    present: Optional[Callable[[Any], bool]] = None,
     default: Any,
 ) -> base_types.GraphType:
-    """Carry `current` forward across turns it is absent. `present(value)` decides
-    whether this turn's value is real (else fall back to `previous`); `default` is
-    the value before any turn has produced one. The latch node + the
+    """Carry `current` forward across turns it is absent. A PRUNED producer (its
+    color inactive this turn) always falls back to `previous`. `present(value)`, if
+    given, additionally treats this turn's PRODUCED value as absent when false --
+    callers whose produced values encode absence (e.g. a consume terminal's
+    all-exposers-pruned sentinel) use it; omit it to latch on pruning ONLY, letting
+    a produced domain-unknown pass through exactly as the always-run baseline would
+    deliver it (latching over it would resurrect a stale value). `default` is the
+    value before any turn has produced one. The latch node + the
     `when_memory_unavailable` default node its future self-edge creates are pinned
     CORE (they are shared carry-forward machinery that must run every turn) so the
     per-color sweep can't mis-color them; `current`'s own subgraph stays
@@ -237,22 +255,26 @@ def latch(
     onto it."""
 
     def carry_forward(current, previous):
-        return current if present(current) else previous
+        if current is _PRUNED:
+            return previous
+        return previous if present is not None and not present(current) else current
 
     def latched(value):  # pass-through: a future-edge-FREE sink, so consumers and
         return value  # `sink_excluding_terminals` resolve cleanly (carry_forward's
         # own future self-edge would otherwise leave the graph with no plain leaf).
 
     def latch_default():
-        return default
+        return _PRUNED
 
-    # `current` enters through a TOLERANT frontier (make_first + a default
-    # fallback): a pruned producer yields `default` (-> not `present` -> previous)
-    # instead of STARVING the pinned carry_forward. Without this guard, a colored
-    # `current` at the pinned-intolerant frontier is caught by the must-run closure,
-    # which forces its whole input cone always-on -- pruning collapses (measured:
-    # bon_secours prunable 50k -> 26k, greeting 257ms -> 11s). A terminal `current`
-    # (the var-bus consume) is already tolerant; the guard is harmless there.
+    # `current` enters through a TOLERANT frontier (make_first + a sentinel
+    # fallback): a pruned producer yields `_PRUNED` (-> previous) instead of
+    # STARVING the pinned carry_forward. Without this guard, a colored `current` at
+    # the pinned-intolerant frontier is caught by the must-run closure, which
+    # forces its whole input cone always-on -- pruning collapses (measured:
+    # bon_secours prunable 50k -> 26k, greeting 257ms -> 11s). The sentinel (not
+    # `default`) is what lets pruned be distinguished from ran-and-returned-unknown.
+    # A terminal `current` (the var-bus consume) is already tolerant; the guard is
+    # harmless there.
     guarded_current = composers.make_first(current, latch_default)
     self_edge = composers.compose_left_future(
         carry_forward, carry_forward, "previous", default

--- a/computation_graph/composers/coloring.py
+++ b/computation_graph/composers/coloring.py
@@ -31,19 +31,6 @@ _EMPTY_ATTR = "__cg_empty__"
 _OBSERVER_ATTR = "__cg_observer__"
 _UNSET = object()
 
-# Each tag is stamped on `func.__dict__` as a `(generation, value)` PAIR. It rides
-# `duplicate_function` for free (functools.wraps copies __dict__), so provenance is
-# recoverable from the assembled graph -- by tag, not by shape. `reset_colors` bumps a
-# module-global build generation and readers IGNORE any tag from an older generation, so
-# an earlier build's colors on a shared-by-reference func (generic combinators,
-# module-level slot defs) are invisible to a later build -- per-build isolation with NO
-# per-func mutation on reset (just one int bump). This matters because the test runner
-# instruments func.__dict__ mutations for dependency tracking: TAGGING is one setattr
-# per tag (unavoidable, cheap), but WIPING the tags per build (the previous approach) was
-# tens of thousands of mutations per build and blew the suite past its timeout. Bumping
-# one int is free.
-_BUILD_GEN = [0]  # current build generation; `reset_colors` increments it
-
 
 # --------------------------------------------------------------------------- #
 # Node selection: sources are caller-seeded and terminals are sinks; neither is
@@ -85,59 +72,27 @@ def _sinks(graph_or_edges) -> FrozenSet[base_types.ComputationNode]:
 
 
 # --------------------------------------------------------------------------- #
-# A tag is stamped on `func.__dict__` as `(generation, value)`, so it rides
-# `duplicate_function` (functools.wraps copies `__dict__`) and is recoverable from the
-# assembled graph. `value` is a FROZENSET of opaque color tokens (colors UNION when
-# more than one author tags the same func -- a building block shared by reference among
-# skills A and B ends up {A, B}), OR the absorbing sentinel `_CORE` meaning "never color
-# this" (a core/shared func stays uncolored even when a skill's sweep passes over a
-# duplicated copy of it). A CORE pin is stamped with `_PERMANENT` so it is valid in
-# EVERY build (core is core everywhere -- always-run, safe); every other tag is valid
-# only in the build generation it was stamped in, so `reset_colors` (a generation bump)
-# invalidates it without touching the func.
+# The color tag rides the func's `__dict__`, so it survives `duplicate_function`
+# (functools.wraps copies `__dict__`) and is recoverable from the assembled graph.
+# The tag is a FROZENSET of opaque color tokens (colors UNION when more than one
+# author tags the same func -- a building block shared by reference among skills A
+# and B ends up {A, B}), OR the absorbing sentinel `_CORE` meaning "never color this"
+# (a core/shared func, pinned at its authoring site, stays uncolored even when a
+# skill's sweep later passes over a duplicated copy of it). Tags are NEVER cleared per
+# build: colors ACCUMULATE, so a func shared across bots ends up multi-colored and
+# always-runs (>=2 colors) -- provenance by tag, immune to a foreign single color.
 # --------------------------------------------------------------------------- #
 _CORE = "\x00cg-core"  # absorbing marker; not a usable color token
-_PERMANENT = -1  # generation sentinel: valid in every build (used for CORE pins)
 
 
-def _tag_func(func, attr: str, value, *, permanent: bool = False) -> None:
-    # Stamp `(generation, value)` onto the func's __dict__ so it rides
-    # `duplicate_function` (functools.wraps copies __dict__). `permanent=True` (CORE
-    # pins) uses a generation that matches every build, so the pin survives resets. No-op
-    # on an un-taggable builtin / C callable -> it stays tag-less, which readers treat as
-    # core.
-    gen = _PERMANENT if permanent else _BUILD_GEN[0]
+def _tag_func(func, attr: str, value) -> None:
+    # The one guarded stamp: write `attr = value` onto the func's __dict__ so it rides
+    # `duplicate_function` (functools.wraps copies __dict__). No-op on an un-taggable
+    # builtin / C callable -> it stays tag-less, which the readers treat as core.
     try:
-        setattr(func, attr, (gen, value))
+        setattr(func, attr, value)
     except (AttributeError, TypeError):
         pass
-
-
-def _tag_get(func, attr: str, default=None):
-    # Read a tag back, honoring the build generation: a tag stamped in an EARLIER build
-    # (gen != current and not _PERMANENT) is invisible -> treated as absent. Cheap C-level
-    # getattr + tuple unpack; called per node during `build_node_activation`.
-    pair = getattr(func, attr, None)
-    if pair is None:
-        return default
-    gen, value = pair
-    if gen == _PERMANENT or gen == _BUILD_GEN[0]:
-        return value
-    return default
-
-
-def reset_colors() -> None:
-    """Invalidate every color/empty/observer tag stamped since the last reset. Call ONCE
-    at the START of each bot build -- before any `add_colors` / `pin_core` / `observer`
-    sweep and before graph construction -- so tags stamped by an EARLIER build cannot
-    leak into a LATER build that reuses the same shared-by-reference funcs (generic
-    combinators, module-level slot defs). Bumps the build generation: O(1) and
-    MUTATION-FREE (it touches no func), so it is cheap even under a test runner that
-    instruments `__dict__` writes. CORE pins are `_PERMANENT` and survive (core is core
-    in every build). Idempotent; a build that never colored is unaffected. Deliberately
-    NOT called mid-build: a multi-skill bot compiles many subgraphs and bumping between
-    them would make the later compiles read as uncolored."""
-    _BUILD_GEN[0] += 1
 
 
 def add_colors(
@@ -155,7 +110,7 @@ def add_colors(
     make_first sinks, and terminals -- which the runner merges via make_or) never
     consult it, so only the genuinely intolerant frontier needs an `empty`."""
     for node in _colorable_nodes(subgraph):
-        current = _tag_get(node.func, _ORIGIN_ATTR)
+        current = getattr(node.func, _ORIGIN_ATTR, None)
         if current == _CORE:
             continue
         _tag_func(node.func, _ORIGIN_ATTR, (current or frozenset()) | colors)
@@ -180,7 +135,7 @@ def _read_empties(
     """node -> its typed-empty, for every node whose func carries an `empty` tag."""
     out: Dict[base_types.ComputationNode, Any] = {}
     for node in graph.get_all_nodes(_edges(graph_or_edges)):
-        value = _tag_get(node.func, _EMPTY_ATTR, _UNSET)
+        value = getattr(node.func, _EMPTY_ATTR, _UNSET)
         if value is not _UNSET:
             out[node] = value
     return out
@@ -189,9 +144,8 @@ def _read_empties(
 def _pin_core_func(func):
     # Pin a single callable CORE (absorbing -- a later color sweep leaves it alone).
     # The CORE tag rides func.__dict__ through duplicate_function, so copies stay core
-    # too. Stamped `_PERMANENT` (survives `reset_colors`): a core func is core in every
-    # build. Returns the func. No-op on un-taggable (builtin/C) callables.
-    _tag_func(func, _ORIGIN_ATTR, _CORE, permanent=True)
+    # too. Returns the func. No-op on un-taggable (builtin/C) callables.
+    _tag_func(func, _ORIGIN_ATTR, _CORE)
     return func
 
 
@@ -221,7 +175,7 @@ def _read_colors(
     """node -> its color set, for every colored node (core / untagged omitted)."""
     out = {}
     for node in graph.get_all_nodes(_edges(graph_or_edges)):
-        tag = _tag_get(node.func, _ORIGIN_ATTR)
+        tag = getattr(node.func, _ORIGIN_ATTR, None)
         if tag and tag != _CORE:
             out[node] = tag
     return out

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -107,16 +107,8 @@ def test_empty_tag_drives_intolerant_frontier_default():
     assert activation.boundary_defaults == {n_a: ("A", "EMPTY"), n_b: ("B", "EMPTY")}
     assert activation.node_to_colors[n_a] == frozenset({"A"})
 
-    sel = graph.make_source()
-
-    def declare(colors):
-        return run.ChangeActiveColors(frozenset(colors))
-
-    g = base_types.merge_graphs(
-        g, composers.compose_left_future(sel, declare, None, None)
-    )
     f = run.to_callable_with_coloring(g, frozenset())
-    out = f({}, {x: 5, sel: {"A"}})  # declarer activates A -> restart runs it
+    out = f({}, {x: 5}, frozenset({"A"}))
     assert calls == ["A"]  # only A ran; B's tagged empty flowed into combine
     assert out[graph.make_computation_node(combine)] == (("A", 5), ("B", "EMPTY"))
 
@@ -197,20 +189,14 @@ def test_latch_survives_pruned_producer():
     latched = coloring.latch(term, present=lambda v: v != UNKNOWN, default=UNKNOWN)
     use_graph = composers.compose_left_unary(latched, use_b)
     coloring.add_colors(frozenset({"B"}), use_graph)  # latch is pinned core -> only use_b colored
-    sel = graph.make_source()
-
-    def declare(colors):
-        return run.ChangeActiveColors(frozenset(colors))
-
     g = base_types.merge_graphs(
         expose_graph,
         composers.compose_left_unary(expose_a, term),  # exposer -> terminal (tolerant)
         use_graph,
-        composers.compose_left_future(sel, declare, None, None),
     )
     f = run.to_callable_with_coloring(g, frozenset())
-    r1 = f({}, {u: "hi", sel: {"A"}})  # turn 1: A active -> exposes the var
-    r2 = f(r1, {u: "hi", sel: {"B"}})  # turn 2: B active, A pruned -> latch holds it
+    r1 = f({}, {u: "hi"}, frozenset({"A"}))  # turn 1: A active -> exposes the var
+    r2 = f(r1, {u: "hi"}, frozenset({"B"}))  # turn 2: B active, A pruned -> latch holds it
 
     assert r2[graph.make_computation_node(use_b)] == WANT
     assert calls == ["A", "B"]  # A ran once (turn 1), B ran once (turn 2)

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -27,7 +27,7 @@ def test_color_tag_survives_duplication():
     colors = coloring._read_colors(duplicated)
 
     colorable = [
-        n for n in graph.get_all_nodes(duplicated)
+        n for n in graph.get_all_nodes(duplicated.edges)
         if not n.is_terminal and not getattr(n.func, "__name__", "").startswith("source:")
     ]
     assert colorable, "expected colorable nodes after duplication"
@@ -94,7 +94,7 @@ def _tagged_make_and(calls, *, with_empties):
     coloring.add_colors(frozenset({"A"}), ga, **empty_a)
     coloring.add_colors(frozenset({"B"}), gb, **empty_b)
     core = composers.compose_dict(combine, {"a": skill_a, "b": skill_b})
-    g = base_types.merge_graphs(ga, gb, core)
+    g = graph.merge_graphs(ga, gb, core, sink_node_or_graph=core)
     return x, g, skill_a, skill_b, combine
 
 
@@ -156,7 +156,7 @@ def test_observer_prunes_with_its_skill():
 
     activation = coloring.build_node_activation_from_edges(obs)
     ever_node = next(
-        n for n in graph.get_all_nodes(obs)
+        n for n in graph.get_all_nodes(obs.edges)
         if getattr(n.func, "__name__", "") == "ever_inner"
     )
     # `memory.ever` marked it an observer, but the builder does NOT special-case
@@ -189,10 +189,11 @@ def test_latch_survives_pruned_producer():
     latched = coloring.latch(term, present=lambda v: v != UNKNOWN, default=UNKNOWN)
     use_graph = composers.compose_left_unary(latched, use_b)
     coloring.add_colors(frozenset({"B"}), use_graph)  # latch is pinned core -> only use_b colored
-    g = base_types.merge_graphs(
+    g = graph.merge_graphs(
         expose_graph,
         composers.compose_left_unary(expose_a, term),  # exposer -> terminal (tolerant)
         use_graph,
+        sink_node_or_graph=use_graph,
     )
     f = run.to_callable_with_coloring(g, frozenset())
     r1 = f({}, {u: "hi"}, frozenset({"A"}))  # turn 1: A active -> exposes the var

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -71,56 +71,6 @@ def test_pin_core_func_is_absorbing():
     assert colors[graph.make_computation_node(private)] == frozenset({"skill-X"})
 
 
-def test_reset_colors_prevents_cross_build_contamination():
-    # `shared` is a build-once, shared-by-reference func (a generic combinator or a
-    # module-level slot def): an EARLIER build colors it, a LATER build reuses the
-    # SAME object. Without reset, the later build inherits the earlier build's color.
-    def shared(x):
-        return x
-
-    # --- build 1 (the "poison" bot) colors the shared func ---
-    build1 = composers.compose_left_unary(graph.make_source(), shared)
-    coloring.add_colors(frozenset({"poison"}), build1)
-    assert coloring._read_colors(build1)[graph.make_computation_node(shared)] == frozenset(
-        {"poison"}
-    )
-
-    # --- build 2 starts: reset bumps the generation, invalidating the tag (no mutation) ---
-    coloring.reset_colors()
-    assert coloring._tag_get(shared, coloring._ORIGIN_ATTR) is None
-
-    # build 2 (a goal bot that colors nothing itself) reuses `shared` -> stays core.
-    build2 = composers.compose_left_unary(graph.make_source(), shared)
-    assert graph.make_computation_node(shared) not in coloring._read_colors(build2)
-
-
-def test_reset_invalidates_gen_scoped_tags_but_keeps_core():
-    def colored(x):
-        return x
-
-    def core(y):
-        return y
-
-    coloring.add_colors(
-        frozenset({"A"}), composers.compose_left_unary(graph.make_source(), colored)
-    )
-    coloring.tag_empty("EMPTY", composers.compose_left_unary(graph.make_source(), colored))
-    coloring._mark_observer(colored)
-    coloring._pin_core_func(core)  # permanent
-    assert coloring._tag_get(colored, coloring._ORIGIN_ATTR) == frozenset({"A"})
-    assert coloring._tag_get(colored, coloring._EMPTY_ATTR, coloring._UNSET) == "EMPTY"
-    assert coloring._tag_get(colored, coloring._OBSERVER_ATTR, False) is True
-    assert coloring._tag_get(core, coloring._ORIGIN_ATTR) == coloring._CORE
-
-    coloring.reset_colors()
-    # gen-scoped tags become invisible after the generation bump...
-    assert coloring._tag_get(colored, coloring._ORIGIN_ATTR) is None
-    assert coloring._tag_get(colored, coloring._EMPTY_ATTR, coloring._UNSET) is coloring._UNSET
-    assert coloring._tag_get(colored, coloring._OBSERVER_ATTR, False) is False
-    # ...but a CORE pin is permanent (core is core in every build).
-    assert coloring._tag_get(core, coloring._ORIGIN_ATTR) == coloring._CORE
-
-
 # --------------------------------------------------------------------------- #
 # Tier 2: build_node_activation_from_edges (tags -> activation)
 # --------------------------------------------------------------------------- #
@@ -212,7 +162,7 @@ def test_observer_prunes_with_its_skill():
     # `memory.ever` marked it an observer, but the builder does NOT special-case
     # observers: a skill-private observer prunes WITH its skill (forcing observer cones
     # always-on was measured to drag in ~the whole graph).
-    assert coloring._tag_get(ever_node.func, coloring._OBSERVER_ATTR, False)
+    assert getattr(ever_node.func, coloring._OBSERVER_ATTR, False)
     assert activation.node_to_colors[ever_node] == frozenset({"A"})
 
 

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -107,8 +107,16 @@ def test_empty_tag_drives_intolerant_frontier_default():
     assert activation.boundary_defaults == {n_a: ("A", "EMPTY"), n_b: ("B", "EMPTY")}
     assert activation.node_to_colors[n_a] == frozenset({"A"})
 
+    sel = graph.make_source()
+
+    def declare(colors):
+        return run.ChangeActiveColors(frozenset(colors))
+
+    g = base_types.merge_graphs(
+        g, composers.compose_left_future(sel, declare, None, None)
+    )
     f = run.to_callable_with_coloring(g, frozenset())
-    out = f({}, {x: 5}, frozenset({"A"}))
+    out = f({}, {x: 5, sel: {"A"}})  # declarer activates A -> restart runs it
     assert calls == ["A"]  # only A ran; B's tagged empty flowed into combine
     assert out[graph.make_computation_node(combine)] == (("A", 5), ("B", "EMPTY"))
 
@@ -143,29 +151,6 @@ def test_single_color_rule_shared_node_always_runs():
     activation = coloring.build_node_activation_from_edges(sub)
     # >=2 colors -> not prunable (shared infra runs every turn).
     assert graph.make_computation_node(shared) not in activation.node_to_colors
-
-
-def test_prune_shared_colors_multicolor_nodes():
-    def shared(v):
-        return v
-
-    x = graph.make_source()
-    sub = composers.compose_left_future(x, shared, None, None)
-    coloring.add_colors(frozenset({"A"}), sub)
-    coloring.add_colors(frozenset({"B"}), sub)  # shared -> {A, B}
-
-    # prune_shared: the shared node carries its full color SET and is prunable -- the
-    # runner skips it only when ALL its colors are inactive (runs on A's or B's turn).
-    activation = coloring.build_node_activation_from_edges(sub, prune_shared=True)
-    n_shared = graph.make_computation_node(shared)
-    assert activation.node_to_colors[n_shared] == frozenset({"A", "B"})
-    # it feeds nothing intolerant -> the must-run closure does not force it on.
-    # (explicit activation -> compile via the null-side-effect curry directly.)
-    f = run.to_callable_with_side_effect(
-        gamla.just(gamla.just(None)), sub, frozenset(), activation
-    )
-    assert f({}, {x: 7}, frozenset({"A"}))[n_shared] == 7  # A active -> shared runs
-    assert n_shared not in f({}, {x: 7}, frozenset({"C"}))  # all colors inactive -> pruned
 
 
 def test_observer_prunes_with_its_skill():
@@ -212,14 +197,20 @@ def test_latch_survives_pruned_producer():
     latched = coloring.latch(term, present=lambda v: v != UNKNOWN, default=UNKNOWN)
     use_graph = composers.compose_left_unary(latched, use_b)
     coloring.add_colors(frozenset({"B"}), use_graph)  # latch is pinned core -> only use_b colored
+    sel = graph.make_source()
+
+    def declare(colors):
+        return run.ChangeActiveColors(frozenset(colors))
+
     g = base_types.merge_graphs(
         expose_graph,
         composers.compose_left_unary(expose_a, term),  # exposer -> terminal (tolerant)
         use_graph,
+        composers.compose_left_future(sel, declare, None, None),
     )
     f = run.to_callable_with_coloring(g, frozenset())
-    r1 = f({}, {u: "hi"}, frozenset({"A"}))  # turn 1: A active -> exposes the var
-    r2 = f(r1, {u: "hi"}, frozenset({"B"}))  # turn 2: B active, A pruned -> latch holds it
+    r1 = f({}, {u: "hi", sel: {"A"}})  # turn 1: A active -> exposes the var
+    r2 = f(r1, {u: "hi", sel: {"B"}})  # turn 2: B active, A pruned -> latch holds it
 
     assert r2[graph.make_computation_node(use_b)] == WANT
     assert calls == ["A", "B"]  # A ran once (turn 1), B ran once (turn 2)

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -201,3 +201,34 @@ def test_latch_survives_pruned_producer():
 
     assert r2[graph.make_computation_node(use_b)] == WANT
     assert calls == ["A", "B"]  # A ran once (turn 1), B ran once (turn 2)
+
+
+def test_latch_distinguishes_pruned_from_ran_unknown():
+    # present OMITTED -> latch on pruning only: a producer that RUNS and returns a
+    # domain-unknown passes it through (the baseline would deliver it); latching
+    # over it would resurrect a stale earlier value.
+    UNKNOWN = "UNKNOWN"
+
+    def expose_a(utterance):  # colored {A}: echoes the utterance as the value
+        return utterance
+
+    def use_b(v):  # core consumer of the latched value
+        return ("B", v)
+
+    u = graph.make_source()
+    expose_graph = composers.compose_left_future(u, expose_a, None, None)
+    coloring.add_colors(frozenset({"A"}), expose_graph)
+    latched = coloring.latch(expose_graph, default=UNKNOWN)
+    use_graph = composers.compose_left_unary(latched, use_b)
+    g = graph.merge_graphs(expose_graph, use_graph, sink_node_or_graph=use_graph)
+    f = run.to_callable_with_coloring(g, frozenset())
+    use_node = graph.make_computation_node(use_b)
+
+    r1 = f({}, {u: "phone:555"}, frozenset({"A"}))  # A runs, real value
+    assert r1[use_node] == ("B", "phone:555")
+    r2 = f(r1, {u: "ignored"}, frozenset())  # A PRUNED -> previous survives
+    assert r2[use_node] == ("B", "phone:555")
+    r3 = f(r2, {u: UNKNOWN}, frozenset({"A"}))  # A RUNS, returns unknown ->
+    assert r3[use_node] == ("B", UNKNOWN)  # passes through, NOT the stale value
+    r4 = f(r3, {u: "ignored"}, frozenset())  # pruned again -> carries the unknown
+    assert r4[use_node] == ("B", UNKNOWN)  # (what the last live run delivered)

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -71,6 +71,45 @@ def test_pin_core_func_is_absorbing():
     assert colors[graph.make_computation_node(private)] == frozenset({"skill-X"})
 
 
+def test_reset_colors_prevents_cross_build_contamination():
+    # `shared` is a build-once, shared-by-reference func (a generic combinator or a
+    # module-level slot def): an EARLIER build colors it, a LATER build reuses the
+    # SAME object. Without reset, the later build inherits the earlier build's color.
+    def shared(x):
+        return x
+
+    # --- build 1 (the "poison" bot) colors the shared func ---
+    build1 = composers.compose_left_unary(graph.make_source(), shared)
+    coloring.add_colors(frozenset({"poison"}), build1)
+    assert getattr(shared, coloring._ORIGIN_ATTR, None) == frozenset({"poison"})
+
+    # --- build 2 starts: reset wipes tags off every shared-by-reference func ---
+    coloring.reset_colors()
+    assert not hasattr(shared, coloring._ORIGIN_ATTR)
+    assert not coloring._TAGGED_FUNCS
+
+    # build 2 (a goal bot that colors nothing itself) reuses `shared` -> stays core.
+    build2 = composers.compose_left_unary(graph.make_source(), shared)
+    assert graph.make_computation_node(shared) not in coloring._read_colors(build2)
+
+
+def test_reset_colors_clears_empty_and_observer_tags():
+    def f(x):
+        return x
+
+    coloring._pin_core_func(f)
+    coloring.tag_empty("EMPTY", composers.compose_left_unary(graph.make_source(), f))
+    coloring._mark_observer(f)
+    assert hasattr(f, coloring._ORIGIN_ATTR)
+    assert hasattr(f, coloring._EMPTY_ATTR)
+    assert hasattr(f, coloring._OBSERVER_ATTR)
+
+    coloring.reset_colors()
+    assert not hasattr(f, coloring._ORIGIN_ATTR)
+    assert not hasattr(f, coloring._EMPTY_ATTR)
+    assert not hasattr(f, coloring._OBSERVER_ATTR)
+
+
 # --------------------------------------------------------------------------- #
 # Tier 2: build_node_activation_from_edges (tags -> activation)
 # --------------------------------------------------------------------------- #

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -1,0 +1,221 @@
+"""Tests for the authoring-time coloring composers (computation_graph.composers.coloring).
+
+The color / empty / observer tags ride `func.__dict__` through duplication, and
+`build_node_activation_from_edges` recovers the whole `run.NodeActivation` from those
+tags: the single-color rule, the tolerance-aware must-run closure, and combiner-aware
+boundary defaults. `latch` carries a value across the turn its producer prunes.
+"""
+import pytest
+
+from computation_graph import base_types, composers, graph, run
+from computation_graph.composers import coloring, duplication, memory
+
+
+def test_color_tag_survives_duplication():
+    def a(x):
+        return x
+
+    def b(y):
+        return y
+
+    x = graph.make_source()
+    sub = composers.compose_dict(b, {"y": composers.compose_left_unary(x, a)})
+    coloring.add_colors(frozenset({"skill-X"}), sub)
+
+    duplicated = duplication.duplicate_graph(sub)
+    colors = coloring.read_colors(duplicated)
+
+    colorable = [
+        n for n in graph.get_all_nodes(duplicated)
+        if not n.is_terminal and not getattr(n.func, "__name__", "").startswith("source:")
+    ]
+    assert colorable, "expected colorable nodes after duplication"
+    assert all(colors.get(n) == frozenset({"skill-X"}) for n in colorable)
+    # genuinely new nodes (duplication changed identity)
+    originals = {graph.make_computation_node(a), graph.make_computation_node(b)}
+    assert not (originals & set(colorable))
+
+
+def test_add_colors_unions_shared_by_reference():
+    def shared(x):
+        return x
+
+    def private(y):
+        return y
+
+    x = graph.make_source()
+    sub_a = composers.compose_left_unary(x, shared)
+    sub_b = composers.compose_left_unary(shared, private)
+    coloring.add_colors(frozenset({"A"}), sub_a)
+    coloring.add_colors(frozenset({"B"}), sub_b)  # `shared` is in both -> union
+
+    colors = coloring.read_colors(sub_b)
+    assert colors[graph.make_computation_node(shared)] == frozenset({"A", "B"})
+    assert colors[graph.make_computation_node(private)] == frozenset({"B"})
+
+
+def test_pin_core_func_is_absorbing():
+    def shared(x):
+        return x
+
+    def private(y):
+        return y
+
+    coloring.pin_core_func(shared)  # the shared building block pins itself core first
+    skill = composers.compose_left_unary(shared, private)
+    coloring.add_colors(frozenset({"skill-X"}), skill)  # sweep can't color `shared`
+
+    colors = coloring.read_colors(skill)
+    assert graph.make_computation_node(shared) not in colors  # stayed core
+    assert colors[graph.make_computation_node(private)] == frozenset({"skill-X"})
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2: build_node_activation_from_edges (tags -> activation)
+# --------------------------------------------------------------------------- #
+def _tagged_make_and(calls, *, with_empties):
+    def skill_a(x):
+        calls.append("A")
+        return ("A", x)
+
+    def skill_b(x):
+        calls.append("B")
+        return ("B", x)
+
+    def combine(a, b):
+        return (a, b)
+
+    x = graph.make_source()
+    ga = composers.compose_left_future(x, skill_a, None, None)
+    gb = composers.compose_left_future(x, skill_b, None, None)
+    empty_a = {"empty": ("A", "EMPTY")} if with_empties else {}
+    empty_b = {"empty": ("B", "EMPTY")} if with_empties else {}
+    coloring.add_colors(frozenset({"A"}), ga, **empty_a)
+    coloring.add_colors(frozenset({"B"}), gb, **empty_b)
+    core = composers.compose_dict(combine, {"a": skill_a, "b": skill_b})
+    g = base_types.merge_graphs(ga, gb, core)
+    return x, g, skill_a, skill_b, combine
+
+
+def test_empty_tag_drives_intolerant_frontier_default():
+    calls = []
+    x, g, skill_a, skill_b, combine = _tagged_make_and(calls, with_empties=True)
+    activation = coloring.build_node_activation_from_edges(g)
+
+    n_a, n_b = graph.make_computation_node(skill_a), graph.make_computation_node(skill_b)
+    assert activation.boundary_defaults == {n_a: ("A", "EMPTY"), n_b: ("B", "EMPTY")}
+    assert activation.node_to_colors[n_a] == frozenset({"A"})
+
+    f = run.to_callable_with_coloring(g, frozenset())
+    out = f({}, {x: 5}, frozenset({"A"}))
+    assert calls == ["A"]  # only A ran; B's tagged empty flowed into combine
+    assert out[graph.make_computation_node(combine)] == (("A", 5), ("B", "EMPTY"))
+
+
+def test_missing_empty_at_intolerant_frontier_raises_in_strict_mode():
+    x, g, skill_a, skill_b, _ = _tagged_make_and([], with_empties=False)
+    with pytest.raises(coloring.BoundaryDefaultRequired) as e:
+        coloring.build_node_activation_from_edges(g, strict=True)
+    assert "skill_a" in str(e.value) and "skill_b" in str(e.value)
+
+
+def test_missing_empty_forces_producer_always_on_by_default():
+    # Graceful (default): an untagged intolerant frontier forces its producer
+    # always-on (core) rather than raising -- safe, never starves the consumer.
+    x, g, skill_a, skill_b, _ = _tagged_make_and([], with_empties=False)
+    activation = coloring.build_node_activation_from_edges(g)
+    n_a, n_b = graph.make_computation_node(skill_a), graph.make_computation_node(skill_b)
+    assert n_a not in activation.node_to_colors  # forced always-on
+    assert n_b not in activation.node_to_colors
+    assert activation.boundary_defaults == {}
+
+
+def test_single_color_rule_shared_node_always_runs():
+    def shared(x):
+        return x
+
+    x = graph.make_source()
+    sub = composers.compose_left_unary(x, shared)
+    coloring.add_colors(frozenset({"A"}), sub)
+    coloring.add_colors(frozenset({"B"}), sub)  # shared -> {A, B}: shared, always-on
+
+    activation = coloring.build_node_activation_from_edges(sub)
+    # >=2 colors -> not prunable (shared infra runs every turn).
+    assert graph.make_computation_node(shared) not in activation.node_to_colors
+
+
+def test_prune_shared_colors_multicolor_nodes():
+    def shared(v):
+        return v
+
+    x = graph.make_source()
+    sub = composers.compose_left_future(x, shared, None, None)
+    coloring.add_colors(frozenset({"A"}), sub)
+    coloring.add_colors(frozenset({"B"}), sub)  # shared -> {A, B}
+
+    # prune_shared: the shared node carries its full color SET and is prunable -- the
+    # runner skips it only when ALL its colors are inactive (runs on A's or B's turn).
+    activation = coloring.build_node_activation_from_edges(sub, prune_shared=True)
+    n_shared = graph.make_computation_node(shared)
+    assert activation.node_to_colors[n_shared] == frozenset({"A", "B"})
+    # it feeds nothing intolerant -> the must-run closure does not force it on.
+    f = run.to_callable_with_node_activation(sub, frozenset(), activation)
+    assert f({}, {x: 7}, frozenset({"A"}))[n_shared] == 7  # A active -> shared runs
+    assert n_shared not in f({}, {x: 7}, frozenset({"C"}))  # all colors inactive -> pruned
+
+
+def test_observer_prunes_with_its_skill():
+    def watched(v):
+        return bool(v)
+
+    coloring.pin_core_func(watched)  # the watched value is core (always-on)
+    x = graph.make_source()
+    obs = memory.ever(composers.compose_left_unary(x, watched))
+    coloring.add_colors(frozenset({"A"}), obs)  # colors ever_inner A
+
+    activation = coloring.build_node_activation_from_edges(obs)
+    ever_node = next(
+        n for n in graph.get_all_nodes(obs)
+        if getattr(n.func, "__name__", "") == "ever_inner"
+    )
+    # `memory.ever` marked it an observer, but the builder does NOT special-case
+    # observers: a skill-private observer prunes WITH its skill (forcing observer cones
+    # always-on was measured to drag in ~the whole graph).
+    assert getattr(ever_node.func, coloring._OBSERVER_ATTR, False)
+    assert activation.node_to_colors[ever_node] == frozenset({"A"})
+
+
+def test_latch_survives_pruned_producer():
+    UNKNOWN = "UNKNOWN"
+    WANT = ("B", "phone:555")
+    calls = []
+
+    def expose_a(utterance):  # skill A exposes the var. colored {A}
+        calls.append("A")
+        return "phone:555"
+
+    def consume_var(val):  # the var terminal: first present exposer or absent
+        return val[0] if len(val) > 0 else UNKNOWN
+
+    def use_b(v):  # skill B reads the var. colored {B}
+        calls.append("B")
+        return ("B", v)
+
+    u = graph.make_source()
+    term = graph.make_terminal("VAR", consume_var)
+    expose_graph = composers.compose_left_future(u, expose_a, None, None)
+    coloring.add_colors(frozenset({"A"}), expose_graph)
+    latched = coloring.latch(term, present=lambda v: v != UNKNOWN, default=UNKNOWN)
+    use_graph = composers.compose_left_unary(latched, use_b)
+    coloring.add_colors(frozenset({"B"}), use_graph)  # latch is pinned core -> only use_b colored
+    g = base_types.merge_graphs(
+        expose_graph,
+        composers.compose_left_unary(expose_a, term),  # exposer -> terminal (tolerant)
+        use_graph,
+    )
+    f = run.to_callable_with_coloring(g, frozenset())
+    r1 = f({}, {u: "hi"}, frozenset({"A"}))  # turn 1: A active -> exposes the var
+    r2 = f(r1, {u: "hi"}, frozenset({"B"}))  # turn 2: B active, A pruned -> latch holds it
+
+    assert r2[graph.make_computation_node(use_b)] == WANT
+    assert calls == ["A", "B"]  # A ran once (turn 1), B ran once (turn 2)

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -5,6 +5,7 @@ The color / empty / observer tags ride `func.__dict__` through duplication, and
 tags: the single-color rule, the tolerance-aware must-run closure, and combiner-aware
 boundary defaults. `latch` carries a value across the turn its producer prunes.
 """
+import gamla
 import pytest
 
 from computation_graph import base_types, composers, graph, run
@@ -23,7 +24,7 @@ def test_color_tag_survives_duplication():
     coloring.add_colors(frozenset({"skill-X"}), sub)
 
     duplicated = duplication.duplicate_graph(sub)
-    colors = coloring.read_colors(duplicated)
+    colors = coloring._read_colors(duplicated)
 
     colorable = [
         n for n in graph.get_all_nodes(duplicated)
@@ -49,7 +50,7 @@ def test_add_colors_unions_shared_by_reference():
     coloring.add_colors(frozenset({"A"}), sub_a)
     coloring.add_colors(frozenset({"B"}), sub_b)  # `shared` is in both -> union
 
-    colors = coloring.read_colors(sub_b)
+    colors = coloring._read_colors(sub_b)
     assert colors[graph.make_computation_node(shared)] == frozenset({"A", "B"})
     assert colors[graph.make_computation_node(private)] == frozenset({"B"})
 
@@ -61,11 +62,11 @@ def test_pin_core_func_is_absorbing():
     def private(y):
         return y
 
-    coloring.pin_core_func(shared)  # the shared building block pins itself core first
+    coloring._pin_core_func(shared)  # the shared building block pins itself core first
     skill = composers.compose_left_unary(shared, private)
     coloring.add_colors(frozenset({"skill-X"}), skill)  # sweep can't color `shared`
 
-    colors = coloring.read_colors(skill)
+    colors = coloring._read_colors(skill)
     assert graph.make_computation_node(shared) not in colors  # stayed core
     assert colors[graph.make_computation_node(private)] == frozenset({"skill-X"})
 
@@ -159,7 +160,10 @@ def test_prune_shared_colors_multicolor_nodes():
     n_shared = graph.make_computation_node(shared)
     assert activation.node_to_colors[n_shared] == frozenset({"A", "B"})
     # it feeds nothing intolerant -> the must-run closure does not force it on.
-    f = run.to_callable_with_node_activation(sub, frozenset(), activation)
+    # (explicit activation -> compile via the null-side-effect curry directly.)
+    f = run.to_callable_with_side_effect(
+        gamla.just(gamla.just(None)), sub, frozenset(), activation
+    )
     assert f({}, {x: 7}, frozenset({"A"}))[n_shared] == 7  # A active -> shared runs
     assert n_shared not in f({}, {x: 7}, frozenset({"C"}))  # all colors inactive -> pruned
 
@@ -168,7 +172,7 @@ def test_observer_prunes_with_its_skill():
     def watched(v):
         return bool(v)
 
-    coloring.pin_core_func(watched)  # the watched value is core (always-on)
+    coloring._pin_core_func(watched)  # the watched value is core (always-on)
     x = graph.make_source()
     obs = memory.ever(composers.compose_left_unary(x, watched))
     coloring.add_colors(frozenset({"A"}), obs)  # colors ever_inner A

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -85,31 +85,40 @@ def test_reset_colors_prevents_cross_build_contamination():
         {"poison"}
     )
 
-    # --- build 2 starts: reset drops the color maps (no per-func mutation) ---
+    # --- build 2 starts: reset bumps the generation, invalidating the tag (no mutation) ---
     coloring.reset_colors()
-    assert not coloring._COLOR_MAP
+    assert coloring._tag_get(shared, coloring._ORIGIN_ATTR) is None
 
     # build 2 (a goal bot that colors nothing itself) reuses `shared` -> stays core.
     build2 = composers.compose_left_unary(graph.make_source(), shared)
     assert graph.make_computation_node(shared) not in coloring._read_colors(build2)
 
 
-def test_reset_colors_clears_empty_and_observer_tags():
-    def f(x):
+def test_reset_invalidates_gen_scoped_tags_but_keeps_core():
+    def colored(x):
         return x
 
-    coloring._pin_core_func(f)
-    coloring.tag_empty("EMPTY", composers.compose_left_unary(graph.make_source(), f))
-    coloring._mark_observer(f)
-    assert coloring._resolve(f, coloring._COLOR_MAP) == coloring._CORE
-    assert coloring._resolve(f, coloring._EMPTY_MAP, coloring._UNSET) == "EMPTY"
-    assert coloring._resolve(f, coloring._OBSERVER_MAP) is True
+    def core(y):
+        return y
+
+    coloring.add_colors(
+        frozenset({"A"}), composers.compose_left_unary(graph.make_source(), colored)
+    )
+    coloring.tag_empty("EMPTY", composers.compose_left_unary(graph.make_source(), colored))
+    coloring._mark_observer(colored)
+    coloring._pin_core_func(core)  # permanent
+    assert coloring._tag_get(colored, coloring._ORIGIN_ATTR) == frozenset({"A"})
+    assert coloring._tag_get(colored, coloring._EMPTY_ATTR, coloring._UNSET) == "EMPTY"
+    assert coloring._tag_get(colored, coloring._OBSERVER_ATTR, False) is True
+    assert coloring._tag_get(core, coloring._ORIGIN_ATTR) == coloring._CORE
 
     coloring.reset_colors()
-    assert not coloring._COLOR_MAP
-    assert not coloring._EMPTY_MAP
-    assert not coloring._OBSERVER_MAP
-    assert coloring._resolve(f, coloring._COLOR_MAP) is None
+    # gen-scoped tags become invisible after the generation bump...
+    assert coloring._tag_get(colored, coloring._ORIGIN_ATTR) is None
+    assert coloring._tag_get(colored, coloring._EMPTY_ATTR, coloring._UNSET) is coloring._UNSET
+    assert coloring._tag_get(colored, coloring._OBSERVER_ATTR, False) is False
+    # ...but a CORE pin is permanent (core is core in every build).
+    assert coloring._tag_get(core, coloring._ORIGIN_ATTR) == coloring._CORE
 
 
 # --------------------------------------------------------------------------- #
@@ -203,7 +212,7 @@ def test_observer_prunes_with_its_skill():
     # `memory.ever` marked it an observer, but the builder does NOT special-case
     # observers: a skill-private observer prunes WITH its skill (forcing observer cones
     # always-on was measured to drag in ~the whole graph).
-    assert coloring._resolve(ever_node.func, coloring._OBSERVER_MAP, False)
+    assert coloring._tag_get(ever_node.func, coloring._OBSERVER_ATTR, False)
     assert activation.node_to_colors[ever_node] == frozenset({"A"})
 
 

--- a/computation_graph/composers/coloring_test.py
+++ b/computation_graph/composers/coloring_test.py
@@ -81,12 +81,13 @@ def test_reset_colors_prevents_cross_build_contamination():
     # --- build 1 (the "poison" bot) colors the shared func ---
     build1 = composers.compose_left_unary(graph.make_source(), shared)
     coloring.add_colors(frozenset({"poison"}), build1)
-    assert getattr(shared, coloring._ORIGIN_ATTR, None) == frozenset({"poison"})
+    assert coloring._read_colors(build1)[graph.make_computation_node(shared)] == frozenset(
+        {"poison"}
+    )
 
-    # --- build 2 starts: reset wipes tags off every shared-by-reference func ---
+    # --- build 2 starts: reset drops the color maps (no per-func mutation) ---
     coloring.reset_colors()
-    assert not hasattr(shared, coloring._ORIGIN_ATTR)
-    assert not coloring._TAGGED_FUNCS
+    assert not coloring._COLOR_MAP
 
     # build 2 (a goal bot that colors nothing itself) reuses `shared` -> stays core.
     build2 = composers.compose_left_unary(graph.make_source(), shared)
@@ -100,14 +101,15 @@ def test_reset_colors_clears_empty_and_observer_tags():
     coloring._pin_core_func(f)
     coloring.tag_empty("EMPTY", composers.compose_left_unary(graph.make_source(), f))
     coloring._mark_observer(f)
-    assert hasattr(f, coloring._ORIGIN_ATTR)
-    assert hasattr(f, coloring._EMPTY_ATTR)
-    assert hasattr(f, coloring._OBSERVER_ATTR)
+    assert coloring._resolve(f, coloring._COLOR_MAP) == coloring._CORE
+    assert coloring._resolve(f, coloring._EMPTY_MAP, coloring._UNSET) == "EMPTY"
+    assert coloring._resolve(f, coloring._OBSERVER_MAP) is True
 
     coloring.reset_colors()
-    assert not hasattr(f, coloring._ORIGIN_ATTR)
-    assert not hasattr(f, coloring._EMPTY_ATTR)
-    assert not hasattr(f, coloring._OBSERVER_ATTR)
+    assert not coloring._COLOR_MAP
+    assert not coloring._EMPTY_MAP
+    assert not coloring._OBSERVER_MAP
+    assert coloring._resolve(f, coloring._COLOR_MAP) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -201,7 +203,7 @@ def test_observer_prunes_with_its_skill():
     # `memory.ever` marked it an observer, but the builder does NOT special-case
     # observers: a skill-private observer prunes WITH its skill (forcing observer cones
     # always-on was measured to drag in ~the whole graph).
-    assert getattr(ever_node.func, coloring._OBSERVER_ATTR, False)
+    assert coloring._resolve(ever_node.func, coloring._OBSERVER_MAP, False)
     assert activation.node_to_colors[ever_node] == frozenset({"A"})
 
 

--- a/computation_graph/composers/memory.py
+++ b/computation_graph/composers/memory.py
@@ -3,16 +3,26 @@ from typing import Any, Callable
 import gamla
 
 from computation_graph import base_types, composers, legacy
+from computation_graph.composers import coloring
+
+# Every combinator here compares-or-accumulates across turns, so its inner node is an
+# observer (`coloring.observer` marks it + pins its future-state machinery core). See
+# coloring.observer: the activation builder does NOT exempt observers -- a skill-private
+# one prunes with its skill (state survives via the reducer {**prev} latch). The mark
+# drives diagnostics / an optional must-tick latch. A pure carry-forward LATCH is not an
+# observer -- which is why `with_state` / `handle_state` themselves are not marked here.
 
 
 def accumulate(f: base_types.GraphOrCallable) -> base_types.GraphType:
     """Accumulate `f`'s results into a `tuple`."""
 
-    @with_state("state", None)
     def accumulate(state, x):
         return *(state or ()), x
 
-    return composers.make_compose(accumulate, f, key="x")
+    return coloring.observer(
+        composers.make_compose(with_state("state", None)(accumulate), f, key="x"),
+        accumulate,
+    )
 
 
 class _NoValueYet:
@@ -23,31 +33,48 @@ _NO_VALUE_YET = _NoValueYet()
 
 
 def changed(f: base_types.GraphOrCallable) -> base_types.GraphType:
-    @legacy.handle_state("memory", _NO_VALUE_YET)
     def check_changed(memory, value_to_watch):
         return legacy.ComputationResult(value_to_watch != memory, value_to_watch)
 
-    return composers.make_compose(check_changed, f, key="value_to_watch")
+    return coloring.observer(
+        composers.make_compose(
+            legacy.handle_state("memory", _NO_VALUE_YET)(check_changed),
+            f,
+            key="value_to_watch",
+        ),
+        check_changed,
+    )
 
 
 def ever(bool_node):
-    @with_state("state", None)
     def ever_inner(state, some_bool):
         return state or some_bool
 
-    return composers.make_compose(ever_inner, bool_node, key="some_bool")
+    return coloring.observer(
+        composers.make_compose(
+            with_state("state", None)(ever_inner), bool_node, key="some_bool"
+        ),
+        ever_inner,
+    )
 
 
 def reduce_with_past_result(
     reduce_with_past: Callable[[Any, Any], Any], f: base_types.GraphOrCallable
 ):
-    @legacy.handle_state("state", None)
     def lag(state, current):
         return legacy.ComputationResult(state, current)
 
-    return composers.compose_dict(
-        reduce_with_past,
-        {"previous": composers.make_compose(lag, f, key="current"), "current": f},
+    return coloring.observer(
+        composers.compose_dict(
+            reduce_with_past,
+            {
+                "previous": composers.make_compose(
+                    legacy.handle_state("state", None)(lag), f, key="current"
+                ),
+                "current": f,
+            },
+        ),
+        lag,
     )
 
 

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -185,9 +185,9 @@ class ChangeActiveColors:
 
     Declarations COMPOSE: independent subgraphs may each declare the colors they
     resolved (e.g. one declarer per routing context), and the runner activates the
-    UNION of every declaration observed in a pass. One turn can thus activate several
-    colors at once; a declarer that resolved nothing contributes nothing rather than
-    vetoing the others.
+    UNION of every declaration observed in a pass (replacing the caller's initial
+    seed). One turn can thus activate several colors at once; a declarer that
+    resolved nothing contributes nothing rather than vetoing the others.
     """
 
     colors: FrozenSet
@@ -216,8 +216,10 @@ class NodeActivation:
       * otherwise `_DepNotFoundError` is raised so the node prunes and the graph
         reducer's `{**prev, **computed}` merge latches its previous value for free.
 
-    ACTIVE COLORS: every run starts with NO active colors -- ONLY the no-color
-    (uncolored) nodes run, layer by layer, skipping colored nodes.
+    ACTIVE COLORS: the CALLER provides an initial color set when it starts the run
+    (the `active_colors` argument of the compiled reducer; optional). The run then
+    proceeds layer by layer skipping colored nodes whose color is not in the active
+    set -- when no initial color is given, ONLY the no-color (uncolored) nodes run.
     If `ChangeActiveColors` events then appear in node results whose UNION differs
     from the active set, the run STARTS OVER with that union as the new active set
     (nodes that were skipped may now need to run); only the colored nodes +
@@ -312,7 +314,7 @@ def _to_callable_with_side_effect_for_single_and_multiple(
 
     if is_async:
 
-        async def final_runner(sources_to_values):
+        async def final_runner(sources_to_values, active_colors=None):
             inputs = translate_source_to_placeholder(sources_to_values)
             all_results = await _run_graph_async(
                 inputs,
@@ -321,13 +323,14 @@ def _to_callable_with_side_effect_for_single_and_multiple(
                 node_to_colors,
                 boundary_defaults,
                 color_dependent,
+                active_colors,
             )
 
             return all_node_side_effects_on_edges(all_results)
 
     else:
 
-        def final_runner(sources_to_values):
+        def final_runner(sources_to_values, active_colors=None):
             return all_node_side_effects_on_edges(
                 _run_graph(
                     translate_source_to_placeholder(sources_to_values),
@@ -336,6 +339,7 @@ def _to_callable_with_side_effect_for_single_and_multiple(
                     node_to_colors,
                     boundary_defaults,
                     color_dependent,
+                    active_colors,
                 )
             )
 
@@ -634,6 +638,7 @@ async def _run_graph_async(
     node_to_colors,
     boundary_defaults,
     color_dependent,
+    initial_colors,
 ):
     node_to_task_or_result = inputs.copy()
     unhandled_exception = None
@@ -642,9 +647,9 @@ async def _run_graph_async(
         base_types.SkipComputationError,
         *handled_exceptions,
     )
-    # The run starts with NO active colors (the empty set is disjoint from every
-    # color, so only the no-color nodes run) until a declaration activates some.
-    active = frozenset()
+    # The caller provides the initial active colors; no initial color -> the empty
+    # set, disjoint from every color, so only the no-color (uncolored) nodes run.
+    active = initial_colors if initial_colors is not None else frozenset()
 
     def _schedule_or_skip(node_executor):
         node = node_executor[0]
@@ -735,13 +740,15 @@ def _run_graph(
     node_to_colors,
     boundary_defaults,
     color_dependent,
+    initial_colors,
 ) -> _NodeToResults:
     accumulated_results = inputs.copy()
-    # The run starts with NO active colors (only no-color nodes run); a
-    # ChangeActiveColors declaration starts the run over, recomputing only the
-    # color-dependent nodes and carrying the rest over. With no coloring
-    # (`to_callable`) the loop runs the whole graph once, exactly as before.
-    active = frozenset()
+    # The caller provides the initial active colors (no color -> empty set -> only
+    # no-color nodes run); a ChangeActiveColors event that declares a different set
+    # starts the run over, recomputing only the color-dependent nodes and carrying
+    # the rest over. With no coloring (`to_callable`) the loop runs the whole graph
+    # once, exactly as before.
+    active = initial_colors if initial_colors is not None else frozenset()
     # Same restart loop as the async runner: run the WHOLE pass, then union the
     # declarations (a later declarer in the toposort must be seen before deciding
     # the active set), and start over if a new color set was declared.
@@ -772,17 +779,21 @@ def _run_graph(
 
 
 def _graph_reducer(graph_callable):
-    def reducer(prev: _NodeToResults, sources: _NodeToResults) -> _NodeToResults:
-        return {**prev, **(graph_callable({**prev, **sources}))}
+    # `active_colors` (optional) is the initial color set the caller provides when
+    # it starts the run; ignored unless the graph has node-activation coloring.
+    def reducer(
+        prev: _NodeToResults, sources: _NodeToResults, active_colors=None
+    ) -> _NodeToResults:
+        return {**prev, **(graph_callable({**prev, **sources}, active_colors))}
 
     return reducer
 
 
 def _async_graph_reducer(graph_callable):
     async def reducer(
-        prev: _NodeToResults, sources: _NodeToResults
+        prev: _NodeToResults, sources: _NodeToResults, active_colors=None
     ) -> _NodeToResults:
-        return {**prev, **(await graph_callable({**prev, **sources}))}
+        return {**prev, **(await graph_callable({**prev, **sources}, active_colors))}
 
     return reducer
 
@@ -804,10 +815,12 @@ def to_callable_with_coloring(
     from the author tags carried on the graph's node funcs (colors and typed-empties;
     observer marks are diagnostic-only and do not affect the activation). The caller
     only tags the graph at composition time (`coloring.add_colors` /
-    `add_colors(..., empty=...)` / `coloring.pin_core`) and emits the
-    `run.ChangeActiveColors` event from its own nodes; this derives the
-    `NodeActivation` generically and compiles with it. Uncolored graphs / plain
-    `to_callable` behave identically to before.
+    `add_colors(..., empty=...)` / `coloring.pin_core`) and
+    emits the `run.ChangeActiveColors` event from its own node; this derives the
+    `NodeActivation` generically and compiles with it. The compiled reducer takes an
+    extra optional `active_colors` argument (the initial color set the caller
+    provides at run start). Uncolored graphs / plain `to_callable` behave identically
+    to before.
 
     Callers that already hold a `NodeActivation` (the engine's own tests, dev
     diagnostics) compile it directly via `to_callable_with_side_effect`."""

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -102,9 +102,6 @@ def _profile(node, time_started: float):
     )
 
 
-_group_by_is_future = opt_gamla.groupby(lambda k_v: asyncio.isfuture(k_v[1]))
-
-
 _is_graph_async = opt_gamla.compose_left(
     opt_gamla.mapcat(lambda edge: (edge.source, *edge.args)),
     opt_gamla.remove(gamla.equals(None)),
@@ -270,7 +267,8 @@ def _to_callable_with_side_effect_for_single_and_multiple(
     )
 
     # Per-node skipping ("coloring"), opt-in by construction: it applies only when a
-    # NodeActivation is supplied (via `to_callable_with_node_activation`). The runner
+    # NodeActivation is supplied (via `to_callable_with_coloring` / the side-effect
+    # curry with a trailing activation). The runner
     # itself does the skip (no executor wrapping): a colored node whose color is not
     # active returns its boundary default (frontier) or is pruned (interior). Plain
     # `to_callable` passes empty maps -> the runner runs the whole graph (zero
@@ -597,7 +595,7 @@ async def _run_graph_async(
     # set, disjoint from every color, so only the no-color (uncolored) nodes run.
     active = initial_colors if initial_colors is not None else frozenset()
 
-    def schedule_or_skip(node_executor):
+    def _schedule_or_skip(node_executor):
         node = node_executor[0]
         colors = node_to_colors.get(node)
         if colors and colors.isdisjoint(active):
@@ -607,6 +605,33 @@ async def _run_graph_async(
             return
         _schedule_node(node_executor, node_to_task_or_result, handled_exceptions)
 
+    async def _gather_pending():
+        # Await every pending future in `node_to_task_or_result` in ONE gather, folding
+        # each result back in place: success -> value, skip-exception -> pruned (absent).
+        # Returns the first unhandled (non-skip) exception, or None. Every future is
+        # awaited regardless of outcome, so no task's exception goes unretrieved. Shared
+        # by the restart loop (which reads results before checking for a color change)
+        # and the final harvest below.
+        pending = [
+            node
+            for node, value in node_to_task_or_result.items()
+            if asyncio.isfuture(value)
+        ]
+        first_unhandled = None
+        for node, result in zip(
+            pending,
+            await asyncio.gather(
+                *(node_to_task_or_result[n] for n in pending), return_exceptions=True
+            ),
+        ):
+            if not isinstance(result, Exception):
+                node_to_task_or_result[node] = result
+            elif isinstance(result, skip_exceptions):
+                node_to_task_or_result.pop(node, None)
+            elif first_unhandled is None:
+                first_unhandled = result
+        return first_unhandled
+
     try:
         # Same restart loop as the sync runner, but a node's result is a Task we must
         # await. We schedule the whole pass first (the tasks run CONCURRENTLY), then
@@ -615,27 +640,12 @@ async def _run_graph_async(
             for node_executor in topological_sorted_nodes:
                 if node_executor[0] in node_to_task_or_result:
                     continue  # carried over (color-independent) or already scheduled
-                schedule_or_skip(node_executor)
+                _schedule_or_skip(node_executor)
             if not color_dependent:
                 break  # no colored nodes -> nothing to restart for
-            pending = [
-                ne[0]
-                for ne in topological_sorted_nodes
-                if inspect.isawaitable(node_to_task_or_result.get(ne[0]))
-            ]
-            for node, result in zip(
-                pending,
-                await asyncio.gather(
-                    *(node_to_task_or_result[n] for n in pending),
-                    return_exceptions=True,
-                ),
-            ):
-                if not isinstance(result, Exception):
-                    node_to_task_or_result[node] = result
-                elif isinstance(result, skip_exceptions):
-                    node_to_task_or_result.pop(node, None)  # skipped -> prune (absent)
-                else:
-                    raise result
+            harvested = await _gather_pending()
+            if harvested is not None:
+                raise harvested
             # The LAST change-color event in the pass wins.
             observed = None
             for node_executor in topological_sorted_nodes:
@@ -653,28 +663,11 @@ async def _run_graph_async(
     except Exception as exc:
         unhandled_exception = exc
     finally:
-        results_by_is_async = _group_by_is_future(node_to_task_or_result.items())
-        async_results = tuple(zip(*results_by_is_async.get(True, ())))
-        sync_results = dict(results_by_is_async.get(False, ()))
-
-        all_results = sync_results
-        if async_results:
-            for (node, node_result) in zip(
-                async_results[0],
-                await asyncio.gather(*async_results[1], return_exceptions=True),
-            ):
-                task_e = node_to_task_or_result[node].exception()
-                if not task_e:
-                    all_results[node] = node_result
-                elif not unhandled_exception and not isinstance(
-                    task_e,
-                    (
-                        _DepNotFoundError,
-                        base_types.SkipComputationError,
-                        *handled_exceptions,
-                    ),
-                ):
-                    unhandled_exception = task_e
+        # Harvest any futures still pending (the whole graph when uncolored / the
+        # color-independent ones when the restart loop broke without gathering).
+        harvested = await _gather_pending()
+        if unhandled_exception is None:
+            unhandled_exception = harvested
         if unhandled_exception:
             # this trick avoids cyclic reference and garbage collection issues
             try:
@@ -683,7 +676,7 @@ async def _run_graph_async(
                 del node_to_task_or_result
                 del unhandled_exception
                 raise e from e
-    return all_results
+    return node_to_task_or_result
 
 
 def _run_graph(
@@ -762,40 +755,29 @@ to_callable = to_callable_with_side_effect(gamla.just(gamla.just(None)))
 # to_callable = to_callable_with_side_effect(graphviz.computation_trace('utterance_computation.dot'))
 
 
-def to_callable_with_node_activation(
-    edges: base_types.GraphType,
-    handled_exceptions: Tuple[Type[Exception], ...],
-    node_activation: NodeActivation,
-) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
-    """Like `to_callable`, but with per-node skipping ("coloring") driven by the
-    given `NodeActivation`. The compiled reducer takes an extra optional
-    `active_colors` argument (the initial color set the caller provides at run
-    start). Uncolored graphs / plain `to_callable` behave identically to before."""
-    return _to_callable_with_side_effect_for_single_and_multiple(
-        _type_check,
-        gamla.just(gamla.just(None)),
-        edges,
-        handled_exceptions,
-        node_activation,
-    )
-
-
 def to_callable_with_coloring(
     edges: base_types.GraphType,
     handled_exceptions: Tuple[Type[Exception], ...],
 ) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
-    """Like `to_callable`, but with per-node skipping derived ENTIRELY from the
-    author tags carried on the graph's node funcs (colors / empties / observer
-    marks) -- no hand-built `NodeActivation`. The caller only tags the graph at
-    composition time (`coloring.add_colors` / `add_colors(..., empty=...)` /
-    `coloring.observer`) and emits the `run.ChangeActiveColors` event from its own
-    node; this derives the activation generically. The compiled reducer takes the
-    same optional `active_colors` argument."""
+    """Like `to_callable`, but with per-node skipping ("coloring") derived ENTIRELY
+    from the author tags carried on the graph's node funcs (colors / empties /
+    observer marks). The caller only tags the graph at composition time
+    (`coloring.add_colors` / `add_colors(..., empty=...)` / `coloring.observer`) and
+    emits the `run.ChangeActiveColors` event from its own node; this derives the
+    `NodeActivation` generically and compiles with it. The compiled reducer takes an
+    extra optional `active_colors` argument (the initial color set the caller
+    provides at run start). Uncolored graphs / plain `to_callable` behave identically
+    to before.
+
+    Callers that already hold a `NodeActivation` (the engine's own tests, dev
+    diagnostics) compile it directly via `to_callable_with_side_effect`."""
     # Local import: `coloring` imports `run`, so importing it at module load would
     # be circular.
     from computation_graph.composers import coloring
 
-    return to_callable_with_node_activation(
+    return _to_callable_with_side_effect_for_single_and_multiple(
+        _type_check,
+        gamla.just(gamla.just(None)),
         edges,
         handled_exceptions,
         coloring.build_node_activation_from_edges(edges),

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -241,8 +241,16 @@ class NodeActivation:
     ACTIVE COLORS: the CALLER provides an initial color set when it starts the run
     (the `active_colors` argument of the compiled reducer; optional). The run then
     proceeds layer by layer skipping colored nodes whose color is not in the active
-    set -- when no initial color is given, ONLY the no-color (uncolored) nodes run.
-    If `ChangeActiveColors` events then appear in node results whose UNION differs
+    set. When no initial color is given (None -- no color information yet, e.g. a
+    conversation's first turns before anything was declared) the run is UNPRUNED:
+    every node runs exactly as under `to_callable`, declarations never narrow the
+    pass, and their union is only recorded (EFFECTIVE_ACTIVE_COLORS_KEY) for the
+    caller to seed next turn. Cross-turn state therefore always captures the
+    conversation's opening context: one-shot `remember` latches hold verdicts only
+    computable at conversation start, so pruning a skill's first-ever turn poisons
+    them permanently. An EXPLICIT empty set is the opposite: prune every colored
+    node. With an explicit initial set,
+    if `ChangeActiveColors` events then appear in node results whose UNION differs
     from the active set, the run STARTS OVER with that union as the new active set
     (nodes that were skipped may now need to run); only the colored nodes +
     everything downstream of them are recomputed, the rest (e.g. an upstream routing
@@ -595,6 +603,20 @@ def _schedule_node(node_executor, node_to_task_or_result, handled_exceptions):
         pass
 
 
+def _declared_union(topological_sorted_nodes, results) -> Optional[FrozenSet]:
+    """The union of every `ChangeActiveColors` in the pass's results, or None when
+    nothing was declared."""
+    declarations = frozenset(
+        value
+        for node_executor in topological_sorted_nodes
+        for value in (results.get(node_executor[0], CG_NO_RESULT),)
+        if isinstance(value, ChangeActiveColors)
+    )
+    if not declarations:
+        return None
+    return frozenset().union(*(d.colors for d in declarations))
+
+
 def _next_active_colors(
     topological_sorted_nodes, results, active: FrozenSet, seen_active_sets: Set
 ) -> Optional[FrozenSet]:
@@ -608,16 +630,8 @@ def _next_active_colors(
     revisits an earlier active set means the declarations depend on the active
     colors themselves, so the loop can never settle -> raises
     `ColorDeclarationsDidNotConverge`. Mutates `seen_active_sets`."""
-    declarations = frozenset(
-        value
-        for node_executor in topological_sorted_nodes
-        for value in (results.get(node_executor[0], CG_NO_RESULT),)
-        if isinstance(value, ChangeActiveColors)
-    )
-    if not declarations:
-        return None
-    observed = frozenset().union(*(d.colors for d in declarations))
-    if observed == active:
+    observed = _declared_union(topological_sorted_nodes, results)
+    if observed is None or observed == active:
         return None
     if observed in seen_active_sets:
         raise ColorDeclarationsDidNotConverge(
@@ -652,14 +666,18 @@ async def _run_graph_async(
         base_types.SkipComputationError,
         *handled_exceptions,
     )
-    # The caller provides the initial active colors; no initial color -> the empty
-    # set, disjoint from every color, so only the no-color (uncolored) nodes run.
-    active = initial_colors if initial_colors is not None else frozenset()
+    # No initial color = no color information yet (e.g. the conversation's first
+    # turns, before anything was ever declared): run UNPRUNED, exactly like an
+    # uncolored graph, so cross-turn state captures everything it would under
+    # `to_callable` -- and don't let mid-run declarations narrow the pass. An
+    # explicit (possibly empty) set means "prune to this".
+    unpruned = initial_colors is None
+    active = frozenset() if unpruned else initial_colors
 
     def _schedule_or_skip(node_executor):
         node = node_executor[0]
         colors = node_to_colors.get(node)
-        if colors and colors.isdisjoint(active):
+        if not unpruned and colors and colors.isdisjoint(active):
             # colored but not active: frontier -> boundary default; interior -> prune.
             if node in boundary_defaults:
                 node_to_task_or_result[node] = boundary_defaults[node]
@@ -708,6 +726,14 @@ async def _run_graph_async(
             harvested = await _gather_pending()
             if harvested is not None:
                 raise harvested
+            if unpruned:
+                # Everything already ran; the declarations only decide what the
+                # caller seeds next turn (via EFFECTIVE_ACTIVE_COLORS_KEY below).
+                active = (
+                    _declared_union(topological_sorted_nodes, node_to_task_or_result)
+                    or frozenset()
+                )
+                break
             observed = _next_active_colors(
                 topological_sorted_nodes,
                 node_to_task_or_result,
@@ -752,12 +778,13 @@ def _run_graph(
     initial_colors,
 ) -> _NodeToResults:
     accumulated_results = inputs.copy()
-    # The caller provides the initial active colors (no color -> empty set -> only
-    # no-color nodes run); a ChangeActiveColors event that declares a different set
-    # starts the run over, recomputing only the color-dependent nodes and carrying
-    # the rest over. With no coloring (`to_callable`) the loop runs the whole graph
-    # once, exactly as before.
-    active = initial_colors if initial_colors is not None else frozenset()
+    # No initial color = no color information yet: run UNPRUNED (see the async
+    # runner's note). An explicit set means "prune to this"; a ChangeActiveColors
+    # event that declares a different set starts the run over, recomputing only the
+    # color-dependent nodes and carrying the rest over. With no coloring
+    # (`to_callable`) the loop runs the whole graph once, exactly as before.
+    unpruned = initial_colors is None
+    active = frozenset() if unpruned else initial_colors
     # Same restart loop as the async runner: run the WHOLE pass, then union the
     # declarations (a later declarer in the toposort must be seen before deciding
     # the active set), and start over if a new color set was declared.
@@ -768,7 +795,7 @@ def _run_graph(
             if node in accumulated_results:
                 continue  # carried over (color-independent) or already run this pass
             colors = node_to_colors.get(node)
-            if colors and colors.isdisjoint(active):
+            if not unpruned and colors and colors.isdisjoint(active):
                 # colored but not active: frontier -> boundary default; interior -> prune.
                 if node in boundary_defaults:
                     accumulated_results[node] = boundary_defaults[node]
@@ -776,6 +803,14 @@ def _run_graph(
             _schedule_node(node_executor, accumulated_results, handled_exceptions)
         if not color_dependent:
             break  # no colored nodes -> nothing to restart for
+        if unpruned:
+            # Everything already ran; the declarations only decide what the caller
+            # seeds next turn (via EFFECTIVE_ACTIVE_COLORS_KEY below).
+            active = (
+                _declared_union(topological_sorted_nodes, accumulated_results)
+                or frozenset()
+            )
+            break
         observed = _next_active_colors(
             topological_sorted_nodes, accumulated_results, active, seen_active_sets
         )

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -185,9 +185,9 @@ class ChangeActiveColors:
 
     Declarations COMPOSE: independent subgraphs may each declare the colors they
     resolved (e.g. one declarer per routing context), and the runner activates the
-    UNION of every declaration observed in a pass (replacing the caller's initial
-    seed). One turn can thus activate several colors at once; a declarer that
-    resolved nothing contributes nothing rather than vetoing the others.
+    UNION of every declaration observed in a pass. One turn can thus activate several
+    colors at once; a declarer that resolved nothing contributes nothing rather than
+    vetoing the others.
     """
 
     colors: FrozenSet
@@ -216,10 +216,8 @@ class NodeActivation:
       * otherwise `_DepNotFoundError` is raised so the node prunes and the graph
         reducer's `{**prev, **computed}` merge latches its previous value for free.
 
-    ACTIVE COLORS: the CALLER provides an initial color set when it starts the run
-    (the `active_colors` argument of the compiled reducer; optional). The run then
-    proceeds layer by layer skipping colored nodes whose color is not in the active
-    set -- when no initial color is given, ONLY the no-color (uncolored) nodes run.
+    ACTIVE COLORS: every run starts with NO active colors -- ONLY the no-color
+    (uncolored) nodes run, layer by layer, skipping colored nodes.
     If `ChangeActiveColors` events then appear in node results whose UNION differs
     from the active set, the run STARTS OVER with that union as the new active set
     (nodes that were skipped may now need to run); only the colored nodes +
@@ -314,7 +312,7 @@ def _to_callable_with_side_effect_for_single_and_multiple(
 
     if is_async:
 
-        async def final_runner(sources_to_values, active_colors=None):
+        async def final_runner(sources_to_values):
             inputs = translate_source_to_placeholder(sources_to_values)
             all_results = await _run_graph_async(
                 inputs,
@@ -323,14 +321,13 @@ def _to_callable_with_side_effect_for_single_and_multiple(
                 node_to_colors,
                 boundary_defaults,
                 color_dependent,
-                active_colors,
             )
 
             return all_node_side_effects_on_edges(all_results)
 
     else:
 
-        def final_runner(sources_to_values, active_colors=None):
+        def final_runner(sources_to_values):
             return all_node_side_effects_on_edges(
                 _run_graph(
                     translate_source_to_placeholder(sources_to_values),
@@ -339,7 +336,6 @@ def _to_callable_with_side_effect_for_single_and_multiple(
                     node_to_colors,
                     boundary_defaults,
                     color_dependent,
-                    active_colors,
                 )
             )
 
@@ -638,7 +634,6 @@ async def _run_graph_async(
     node_to_colors,
     boundary_defaults,
     color_dependent,
-    initial_colors,
 ):
     node_to_task_or_result = inputs.copy()
     unhandled_exception = None
@@ -647,23 +642,15 @@ async def _run_graph_async(
         base_types.SkipComputationError,
         *handled_exceptions,
     )
-    # The caller provides the initial active colors; no initial color -> the empty
-    # set, disjoint from every color, so only the no-color (uncolored) nodes run.
-    active = initial_colors if initial_colors is not None else frozenset()
-
-    _skip_filter = os.getenv("CG_SKIP_TRACE")
+    # The run starts with NO active colors (the empty set is disjoint from every
+    # color, so only the no-color nodes run) until a declaration activates some.
+    active = frozenset()
 
     def _schedule_or_skip(node_executor):
         node = node_executor[0]
         colors = node_to_colors.get(node)
         if colors and colors.isdisjoint(active):
             # colored but not active: frontier -> boundary default; interior -> prune.
-            if _skip_filter and any(
-                s in str(node) for s in _skip_filter.split("|")
-            ):
-                logging.error(
-                    f"[CG-SKIP] {node} colors={sorted(map(str, colors))} active={sorted(map(str, active))}"
-                )
             if node in boundary_defaults:
                 node_to_task_or_result[node] = boundary_defaults[node]
             return
@@ -748,15 +735,13 @@ def _run_graph(
     node_to_colors,
     boundary_defaults,
     color_dependent,
-    initial_colors,
 ) -> _NodeToResults:
     accumulated_results = inputs.copy()
-    # The caller provides the initial active colors (no color -> empty set -> only
-    # no-color nodes run); a ChangeActiveColors event that declares a different set
-    # starts the run over, recomputing only the color-dependent nodes and carrying
-    # the rest over. With no coloring (`to_callable`) the loop runs the whole graph
-    # once, exactly as before.
-    active = initial_colors if initial_colors is not None else frozenset()
+    # The run starts with NO active colors (only no-color nodes run); a
+    # ChangeActiveColors declaration starts the run over, recomputing only the
+    # color-dependent nodes and carrying the rest over. With no coloring
+    # (`to_callable`) the loop runs the whole graph once, exactly as before.
+    active = frozenset()
     # Same restart loop as the async runner: run the WHOLE pass, then union the
     # declarations (a later declarer in the toposort must be seen before deciding
     # the active set), and start over if a new color set was declared.
@@ -787,21 +772,17 @@ def _run_graph(
 
 
 def _graph_reducer(graph_callable):
-    # `active_colors` (optional) is the initial color set the caller provides when
-    # it starts the run; ignored unless the graph has node-activation coloring.
-    def reducer(
-        prev: _NodeToResults, sources: _NodeToResults, active_colors=None
-    ) -> _NodeToResults:
-        return {**prev, **(graph_callable({**prev, **sources}, active_colors))}
+    def reducer(prev: _NodeToResults, sources: _NodeToResults) -> _NodeToResults:
+        return {**prev, **(graph_callable({**prev, **sources}))}
 
     return reducer
 
 
 def _async_graph_reducer(graph_callable):
     async def reducer(
-        prev: _NodeToResults, sources: _NodeToResults, active_colors=None
+        prev: _NodeToResults, sources: _NodeToResults
     ) -> _NodeToResults:
-        return {**prev, **(await graph_callable({**prev, **sources}, active_colors))}
+        return {**prev, **(await graph_callable({**prev, **sources}))}
 
     return reducer
 
@@ -820,14 +801,13 @@ def to_callable_with_coloring(
     handled_exceptions: Tuple[Type[Exception], ...],
 ) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
     """Like `to_callable`, but with per-node skipping ("coloring") derived ENTIRELY
-    from the author tags carried on the graph's node funcs (colors / empties /
-    observer marks). The caller only tags the graph at composition time
-    (`coloring.add_colors` / `add_colors(..., empty=...)` / `coloring.observer`) and
-    emits the `run.ChangeActiveColors` event from its own node; this derives the
-    `NodeActivation` generically and compiles with it. The compiled reducer takes an
-    extra optional `active_colors` argument (the initial color set the caller
-    provides at run start). Uncolored graphs / plain `to_callable` behave identically
-    to before.
+    from the author tags carried on the graph's node funcs (colors and typed-empties;
+    observer marks are diagnostic-only and do not affect the activation). The caller
+    only tags the graph at composition time (`coloring.add_colors` /
+    `add_colors(..., empty=...)` / `coloring.pin_core`) and emits the
+    `run.ChangeActiveColors` event from its own nodes; this derives the
+    `NodeActivation` generically and compiles with it. Uncolored graphs / plain
+    `to_callable` behave identically to before.
 
     Callers that already hold a `NodeActivation` (the engine's own tests, dev
     diagnostics) compile it directly via `to_callable_with_side_effect`."""

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -590,6 +590,47 @@ def _schedule_node(node_executor, node_to_task_or_result, handled_exceptions):
         pass
 
 
+def _next_active_colors(
+    topological_sorted_nodes, results, active: FrozenSet, seen_active_sets: Set
+) -> Optional[FrozenSet]:
+    """Decide the restart loop's next active set from the pass's results.
+
+    Declarations COMPOSE: independent declarers each contribute the colors they
+    resolved, and the pass's active set is the UNION of every `ChangeActiveColors`
+    observed (an empty declaration contributes nothing). Returns the NEW active set
+    (the caller restarts with it), or None when the run has settled -- nothing was
+    declared (the seed stands) or the union already matches `active`. A union that
+    revisits an earlier active set means the declarations depend on the active
+    colors themselves, so the loop can never settle -> raises
+    `ColorDeclarationsDidNotConverge`. Mutates `seen_active_sets`."""
+    declarations = frozenset(
+        value
+        for node_executor in topological_sorted_nodes
+        for value in (results.get(node_executor[0], CG_NO_RESULT),)
+        if isinstance(value, ChangeActiveColors)
+    )
+    if not declarations:
+        return None
+    observed = frozenset().union(*(d.colors for d in declarations))
+    if observed == active:
+        return None
+    if observed in seen_active_sets:
+        raise ColorDeclarationsDidNotConverge(
+            f"{sorted(map(str, observed))} was already active this run"
+        )
+    seen_active_sets.add(observed)
+    return observed
+
+
+def _drop_color_dependent(results, color_dependent: FrozenSet) -> None:
+    # Start a restarted pass clean: forget the color-dependent results (they are
+    # recomputed under the new active set); everything else (e.g. upstream routing /
+    # async work) carries over so it is never repeated.
+    for node in tuple(results):
+        if node in color_dependent:
+            del results[node]
+
+
 async def _run_graph_async(
     inputs,
     handled_exceptions,
@@ -670,35 +711,17 @@ async def _run_graph_async(
             harvested = await _gather_pending()
             if harvested is not None:
                 raise harvested
-            # Declarations COMPOSE: the pass's active set is the UNION of every
-            # ChangeActiveColors observed (independent declarers each contribute the
-            # colors they resolved; an empty declaration contributes nothing).
-            declarations = frozenset(
-                value
-                for node_executor in topological_sorted_nodes
-                for value in (
-                    node_to_task_or_result.get(node_executor[0], CG_NO_RESULT),
-                )
-                if isinstance(value, ChangeActiveColors)
+            observed = _next_active_colors(
+                topological_sorted_nodes,
+                node_to_task_or_result,
+                active,
+                seen_active_sets,
             )
-            if not declarations:
-                break  # nothing declared -> the seed stands
-            observed = frozenset().union(*(d.colors for d in declarations))
-            if observed == active:
-                break  # no new color -> done
-            # Revisiting an earlier active set means the declarations depend on the
-            # active colors themselves -> the loop can never settle; fail loudly.
-            if observed in seen_active_sets:
-                raise ColorDeclarationsDidNotConverge(
-                    f"{sorted(map(str, observed))} was already active this run"
-                )
-            seen_active_sets.add(observed)
-            # A new color set was declared -> START OVER with it, recomputing only
-            # the color-dependent nodes; the rest (routing / async work) carry over.
+            if observed is None:
+                break  # settled: nothing declared, or the union matches
+            # A new color set was declared -> START OVER with it.
             active = observed
-            for node in tuple(node_to_task_or_result):
-                if node in color_dependent:
-                    del node_to_task_or_result[node]
+            _drop_color_dependent(node_to_task_or_result, color_dependent)
     except Exception as exc:
         unhandled_exception = exc
     finally:
@@ -752,33 +775,14 @@ def _run_graph(
             _schedule_node(node_executor, accumulated_results, handled_exceptions)
         if not color_dependent:
             break  # no colored nodes -> nothing to restart for
-        # Declarations COMPOSE: the pass's active set is the UNION of every
-        # ChangeActiveColors observed (independent declarers each contribute the
-        # colors they resolved; an empty declaration contributes nothing).
-        declarations = frozenset(
-            value
-            for node_executor in topological_sorted_nodes
-            for value in (accumulated_results.get(node_executor[0], CG_NO_RESULT),)
-            if isinstance(value, ChangeActiveColors)
+        observed = _next_active_colors(
+            topological_sorted_nodes, accumulated_results, active, seen_active_sets
         )
-        if not declarations:
-            break  # nothing declared -> the seed stands
-        observed = frozenset().union(*(d.colors for d in declarations))
-        if observed == active:
-            break  # no new color -> done
-        # Revisiting an earlier active set means the declarations depend on the
-        # active colors themselves -> the loop can never settle; fail loudly.
-        if observed in seen_active_sets:
-            raise ColorDeclarationsDidNotConverge(
-                f"{sorted(map(str, observed))} was already active this run"
-            )
-        seen_active_sets.add(observed)
-        # A new color set was declared -> start over with it, recomputing only the
-        # color-dependent nodes (routing/core carry over).
+        if observed is None:
+            break  # settled: nothing declared, or the union matches
+        # A new color set was declared -> start over with it.
         active = observed
-        for n in tuple(accumulated_results):
-            if n in color_dependent:
-                del accumulated_results[n]
+        _drop_color_dependent(accumulated_results, color_dependent)
     return accumulated_results
 
 

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -172,11 +172,63 @@ def _merge_edges_pointing_to_terminals(g: base_types.GraphType) -> base_types.Gr
     )(g)
 
 
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangeActiveColors:
+    """The CG-native CHANGE-COLOR EVENT. A node RETURNS this value to declare the
+    set of colors that are active for node-activation skipping. The runner reads it
+    out of node results -- it is the ONLY way the active colors are set, so the
+    engine never needs to know what colors mean (skills, etc. -- that is entirely
+    the caller's concern).
+
+    The colors are opaque hashable tokens, matched against `node_to_colors`. An
+    EMPTY set means "no color is active" -> every colored node skips (e.g. a turn
+    that resolved to no skill).
+    """
+
+    colors: FrozenSet
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class NodeActivation:
+    """Opt-in spec for runner-level node skipping (per-node "coloring").
+
+    The engine stays domain-agnostic: it knows only COLORS (opaque tokens) and the
+    `ChangeActiveColors` event. The caller colors the nodes and emits the event from
+    its own nodes; nothing skill/route/VIC-specific reaches the engine.
+
+    SKIP RULE -- when a node's color-set is DISJOINT from the active colors:
+      * if the node is in `boundary_defaults` (a colored->uncolored frontier that
+        feeds shared recombination, e.g. an aggregation/terminal), its typed-empty
+        default value is returned so downstream make_and/aggregation stays
+        well-formed (the per-node, build-time, correctly-typed sentinel);
+      * otherwise `_DepNotFoundError` is raised so the node prunes and the graph
+        reducer's `{**prev, **computed}` merge latches its previous value for free.
+
+    ACTIVE COLORS: the CALLER provides an initial color set when it starts the run
+    (the `active_colors` argument of the compiled reducer; optional). The run then
+    proceeds layer by layer skipping colored nodes whose color is not in the active
+    set -- when no initial color is given, ONLY the no-color (uncolored) nodes run.
+    If a `ChangeActiveColors` event then appears in a node result with a DIFFERENT
+    color set, the run STARTS OVER with the new active set (nodes that were skipped
+    may now need to run); only the colored nodes + everything downstream of them are
+    recomputed, the rest (e.g. an upstream routing model call) is carried over so it
+    is never repeated. The restart happens at most once (the color resolves once).
+    """
+
+    node_to_colors: Mapping[base_types.ComputationNode, FrozenSet]
+    boundary_defaults: Mapping[base_types.ComputationNode, Any] = dataclasses.field(
+        default_factory=dict
+    )
+
+
 def _to_callable_with_side_effect_for_single_and_multiple(
     single_node_side_effect: _SingleNodeSideEffect,
     all_nodes_side_effect: Callable,
     edges: base_types.GraphType,
     handled_exceptions: Tuple[Type[Exception], ...],
+    node_activation: Optional[NodeActivation] = None,
 ) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
     edges = _merge_edges_pointing_to_terminals(edges)
     single_node_side_effect = (
@@ -217,6 +269,30 @@ def _to_callable_with_side_effect_for_single_and_multiple(
         opt_gamla.maptuple(opt_gamla.pair_right(get_node_executor)),
     )
 
+    # Per-node skipping ("coloring"), opt-in by construction: it applies only when a
+    # NodeActivation is supplied (via `to_callable_with_node_activation`). The runner
+    # itself does the skip (no executor wrapping): a colored node whose color is not
+    # active returns its boundary default (frontier) or is pruned (interior). Plain
+    # `to_callable` passes empty maps -> the runner runs the whole graph (zero
+    # behavior change for every existing caller). `color_dependent` = colored nodes
+    # + everything downstream of them (recomputed on a restart; the rest carries
+    # over so upstream async work is never repeated).
+    node_to_colors: Mapping = (
+        node_activation.node_to_colors if node_activation is not None else {}
+    )
+    boundary_defaults: Mapping = (
+        node_activation.boundary_defaults if node_activation is not None else {}
+    )
+    color_dependent: FrozenSet = (
+        frozenset(
+            gamla.graph_traverse_many(
+                tuple(node_to_colors), graph.traverse_forward(edges)
+            )
+        )
+        if node_to_colors
+        else frozenset()
+    )
+
     translate_source_to_placeholder = opt_gamla.compose_left(
         opt_gamla.keyfilter(gamla.contains(future_sources)),
         opt_gamla.keymap(future_source_to_placeholder.__getitem__),
@@ -225,22 +301,32 @@ def _to_callable_with_side_effect_for_single_and_multiple(
 
     if is_async:
 
-        async def final_runner(sources_to_values):
+        async def final_runner(sources_to_values, active_colors=None):
             inputs = translate_source_to_placeholder(sources_to_values)
             all_results = await _run_graph_async(
-                inputs, handled_exceptions, topological_sorted_nodes
+                inputs,
+                handled_exceptions,
+                topological_sorted_nodes,
+                node_to_colors,
+                boundary_defaults,
+                color_dependent,
+                active_colors,
             )
 
             return all_node_side_effects_on_edges(all_results)
 
     else:
 
-        def final_runner(sources_to_values):
+        def final_runner(sources_to_values, active_colors=None):
             return all_node_side_effects_on_edges(
                 _run_graph(
                     translate_source_to_placeholder(sources_to_values),
                     handled_exceptions,
                     topological_sorted_nodes,
+                    node_to_colors,
+                    boundary_defaults,
+                    color_dependent,
+                    active_colors,
                 )
             )
 
@@ -482,21 +568,88 @@ def _make_get_node_executor(
     return get_executor
 
 
-async def _run_graph_async(inputs, handled_exceptions, topological_sorted_nodes):
+def _schedule_node(node_executor, node_to_task_or_result, handled_exceptions):
+    try:
+        node_to_task_or_result[node_executor[0]] = node_executor[1](
+            node_to_task_or_result, node_executor[0]
+        )
+    except (_DepNotFoundError, base_types.SkipComputationError, *handled_exceptions):
+        pass
+
+
+async def _run_graph_async(
+    inputs,
+    handled_exceptions,
+    topological_sorted_nodes,
+    node_to_colors,
+    boundary_defaults,
+    color_dependent,
+    initial_colors,
+):
     node_to_task_or_result = inputs.copy()
     unhandled_exception = None
+    skip_exceptions = (
+        _DepNotFoundError,
+        base_types.SkipComputationError,
+        *handled_exceptions,
+    )
+    # The caller provides the initial active colors; no initial color -> the empty
+    # set, disjoint from every color, so only the no-color (uncolored) nodes run.
+    active = initial_colors if initial_colors is not None else frozenset()
+
+    def schedule_or_skip(node_executor):
+        node = node_executor[0]
+        colors = node_to_colors.get(node)
+        if colors and colors.isdisjoint(active):
+            # colored but not active: frontier -> boundary default; interior -> prune.
+            if node in boundary_defaults:
+                node_to_task_or_result[node] = boundary_defaults[node]
+            return
+        _schedule_node(node_executor, node_to_task_or_result, handled_exceptions)
+
     try:
-        for node_executor in topological_sorted_nodes:
-            try:
-                node_to_task_or_result[node_executor[0]] = node_executor[1](
-                    node_to_task_or_result, node_executor[0]
-                )
-            except (
-                _DepNotFoundError,
-                base_types.SkipComputationError,
-                *handled_exceptions,
+        # Same restart loop as the sync runner, but a node's result is a Task we must
+        # await. We schedule the whole pass first (the tasks run CONCURRENTLY), then
+        # gather them together (not one-by-one) before checking for a color change.
+        while True:
+            for node_executor in topological_sorted_nodes:
+                if node_executor[0] in node_to_task_or_result:
+                    continue  # carried over (color-independent) or already scheduled
+                schedule_or_skip(node_executor)
+            if not color_dependent:
+                break  # no colored nodes -> nothing to restart for
+            pending = [
+                ne[0]
+                for ne in topological_sorted_nodes
+                if inspect.isawaitable(node_to_task_or_result.get(ne[0]))
+            ]
+            for node, result in zip(
+                pending,
+                await asyncio.gather(
+                    *(node_to_task_or_result[n] for n in pending),
+                    return_exceptions=True,
+                ),
             ):
-                pass
+                if not isinstance(result, Exception):
+                    node_to_task_or_result[node] = result
+                elif isinstance(result, skip_exceptions):
+                    node_to_task_or_result.pop(node, None)  # skipped -> prune (absent)
+                else:
+                    raise result
+            # The LAST change-color event in the pass wins.
+            observed = None
+            for node_executor in topological_sorted_nodes:
+                value = node_to_task_or_result.get(node_executor[0], CG_NO_RESULT)
+                if isinstance(value, ChangeActiveColors):
+                    observed = value.colors
+            if observed is None or observed == active:
+                break  # no new color -> done
+            # A different color was declared -> START OVER with it, recomputing only
+            # the color-dependent nodes; the rest (routing / async work) carry over.
+            active = observed
+            for node in tuple(node_to_task_or_result):
+                if node in color_dependent:
+                    del node_to_task_or_result[node]
     except Exception as exc:
         unhandled_exception = exc
     finally:
@@ -537,32 +690,65 @@ def _run_graph(
     inputs: dict,
     handled_exceptions,
     topological_sorted_nodes: tuple[tuple[base_types.ComputationNode, _NodeExecutor]],
+    node_to_colors,
+    boundary_defaults,
+    color_dependent,
+    initial_colors,
 ) -> _NodeToResults:
     accumulated_results = inputs.copy()
-    for node_executor in topological_sorted_nodes:
-        try:
-            accumulated_results[node_executor[0]] = node_executor[1](
-                accumulated_results, node_executor[0]
-            )
-        except (
-            _DepNotFoundError,
-            base_types.SkipComputationError,
-            *handled_exceptions,
-        ):
-            pass
+    # The caller provides the initial active colors (no color -> empty set -> only
+    # no-color nodes run); a ChangeActiveColors event that declares a different set
+    # starts the run over, recomputing only the color-dependent nodes and carrying
+    # the rest over. With no coloring (`to_callable`) the loop runs the whole graph
+    # once, exactly as before.
+    active = initial_colors if initial_colors is not None else frozenset()
+    restart = True
+    while restart:
+        restart = False
+        for node_executor in topological_sorted_nodes:
+            node = node_executor[0]
+            if node in accumulated_results:
+                continue  # carried over (color-independent) or already run this pass
+            colors = node_to_colors.get(node)
+            if colors and colors.isdisjoint(active):
+                # colored but not active: frontier -> boundary default; interior -> prune.
+                if node in boundary_defaults:
+                    accumulated_results[node] = boundary_defaults[node]
+                continue
+            _schedule_node(node_executor, accumulated_results, handled_exceptions)
+            value = accumulated_results.get(node, CG_NO_RESULT)
+            # A node that declares a NEW active color -> start over with it,
+            # recomputing only the color-dependent nodes (routing/core carry over).
+            if (
+                color_dependent
+                and isinstance(value, ChangeActiveColors)
+                and value.colors != active
+            ):
+                active = value.colors
+                for n in tuple(accumulated_results):
+                    if n in color_dependent:
+                        del accumulated_results[n]
+                restart = True
+                break
     return accumulated_results
 
 
 def _graph_reducer(graph_callable):
-    def reducer(prev: _NodeToResults, sources: _NodeToResults) -> _NodeToResults:
-        return {**prev, **(graph_callable({**prev, **sources}))}
+    # `active_colors` (optional) is the initial color set the caller provides when
+    # it starts the run; ignored unless the graph has node-activation coloring.
+    def reducer(
+        prev: _NodeToResults, sources: _NodeToResults, active_colors=None
+    ) -> _NodeToResults:
+        return {**prev, **(graph_callable({**prev, **sources}, active_colors))}
 
     return reducer
 
 
 def _async_graph_reducer(graph_callable):
-    async def reducer(prev: _NodeToResults, sources: _NodeToResults) -> _NodeToResults:
-        return {**prev, **(await graph_callable({**prev, **sources}))}
+    async def reducer(
+        prev: _NodeToResults, sources: _NodeToResults, active_colors=None
+    ) -> _NodeToResults:
+        return {**prev, **(await graph_callable({**prev, **sources}, active_colors))}
 
     return reducer
 
@@ -574,6 +760,46 @@ to_callable_with_side_effect = gamla.curry(
 # Use the second line if you want to see the winning path in the computation graph (a little slower).
 to_callable = to_callable_with_side_effect(gamla.just(gamla.just(None)))
 # to_callable = to_callable_with_side_effect(graphviz.computation_trace('utterance_computation.dot'))
+
+
+def to_callable_with_node_activation(
+    edges: base_types.GraphType,
+    handled_exceptions: Tuple[Type[Exception], ...],
+    node_activation: NodeActivation,
+) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
+    """Like `to_callable`, but with per-node skipping ("coloring") driven by the
+    given `NodeActivation`. The compiled reducer takes an extra optional
+    `active_colors` argument (the initial color set the caller provides at run
+    start). Uncolored graphs / plain `to_callable` behave identically to before."""
+    return _to_callable_with_side_effect_for_single_and_multiple(
+        _type_check,
+        gamla.just(gamla.just(None)),
+        edges,
+        handled_exceptions,
+        node_activation,
+    )
+
+
+def to_callable_with_coloring(
+    edges: base_types.GraphType,
+    handled_exceptions: Tuple[Type[Exception], ...],
+) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
+    """Like `to_callable`, but with per-node skipping derived ENTIRELY from the
+    author tags carried on the graph's node funcs (colors / empties / observer
+    marks) -- no hand-built `NodeActivation`. The caller only tags the graph at
+    composition time (`coloring.add_colors` / `add_colors(..., empty=...)` /
+    `coloring.observer`) and emits the `run.ChangeActiveColors` event from its own
+    node; this derives the activation generically. The compiled reducer takes the
+    same optional `active_colors` argument."""
+    # Local import: `coloring` imports `run`, so importing it at module load would
+    # be circular.
+    from computation_graph.composers import coloring
+
+    return to_callable_with_node_activation(
+        edges,
+        handled_exceptions,
+        coloring.build_node_activation_from_edges(edges),
+    )
 
 
 def _node_is_properly_composed(

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -205,6 +205,16 @@ class ChangeActiveColors:
     colors: FrozenSet
 
 
+# The reserved results key under which the colored runner records the turn's SETTLED
+# effective active-color set (the union the restart loop converged on). Callers that
+# persist state across turns should carry this value forward as the NEXT run's seed
+# `active_colors`: it survives the restart intact, unlike any single declarer node,
+# which is color-dependent and prunes when the settled colors differ from its own
+# declaration (e.g. a mid-flow route change -> the new skill's declarer prunes under
+# the newly-active color, so its declaration is lost). Domain-agnostic: just colors.
+EFFECTIVE_ACTIVE_COLORS_KEY = "__cg_effective_active_colors__"
+
+
 class ColorDeclarationsDidNotConverge(Exception):
     """The unioned `ChangeActiveColors` declarations cycled back to an active set
     this run already had -- the declarations depend on the active colors themselves,
@@ -725,6 +735,10 @@ async def _run_graph_async(
                 del node_to_task_or_result
                 del unhandled_exception
                 raise e from e
+    if color_dependent:
+        # Record the SETTLED active set so the caller can seed it next turn (see
+        # EFFECTIVE_ACTIVE_COLORS_KEY): survives restarts that the declarer nodes do not.
+        node_to_task_or_result[EFFECTIVE_ACTIVE_COLORS_KEY] = ChangeActiveColors(active)
     return node_to_task_or_result
 
 
@@ -770,6 +784,10 @@ def _run_graph(
         # A new color set was declared -> start over with it.
         active = observed
         _drop_color_dependent(accumulated_results, color_dependent)
+    if color_dependent:
+        # Record the SETTLED active set so the caller can seed it next turn (see
+        # EFFECTIVE_ACTIVE_COLORS_KEY): survives restarts that the declarer nodes do not.
+        accumulated_results[EFFECTIVE_ACTIVE_COLORS_KEY] = ChangeActiveColors(active)
     return accumulated_results
 
 

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -250,11 +250,11 @@ class NodeActivation:
 def _to_callable_with_side_effect_for_single_and_multiple(
     single_node_side_effect: _SingleNodeSideEffect,
     all_nodes_side_effect: Callable,
-    graph: base_types.GraphType,
+    input_graph: base_types.GraphType,
     handled_exceptions: Tuple[Type[Exception], ...],
     node_activation: Optional[NodeActivation] = None,
 ) -> Callable[[_NodeToResults, _NodeToResults], _NodeToResults]:
-    edges = _merge_edges_pointing_to_terminals(graph).edges
+    edges = _merge_edges_pointing_to_terminals(input_graph).edges
     single_node_side_effect = (
         (lambda node, result: result)
         if os.getenv(base_types.COMPUTATION_GRAPH_DEBUG_ENV_KEY) is None

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -180,11 +180,24 @@ class ChangeActiveColors:
     the caller's concern).
 
     The colors are opaque hashable tokens, matched against `node_to_colors`. An
-    EMPTY set means "no color is active" -> every colored node skips (e.g. a turn
-    that resolved to no skill).
+    EMPTY set means "this declarer resolved no color" -> alone it activates nothing
+    (e.g. a turn that resolved to no skill).
+
+    Declarations COMPOSE: independent subgraphs may each declare the colors they
+    resolved (e.g. one declarer per routing context), and the runner activates the
+    UNION of every declaration observed in a pass (replacing the caller's initial
+    seed). One turn can thus activate several colors at once; a declarer that
+    resolved nothing contributes nothing rather than vetoing the others.
     """
 
     colors: FrozenSet
+
+
+class ColorDeclarationsDidNotConverge(Exception):
+    """The unioned `ChangeActiveColors` declarations cycled back to an active set
+    this run already had -- the declarations depend on the active colors themselves,
+    so the restart loop can never settle. Declarers must derive their colors from
+    always-on (uncolored) inputs only."""
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -207,11 +220,13 @@ class NodeActivation:
     (the `active_colors` argument of the compiled reducer; optional). The run then
     proceeds layer by layer skipping colored nodes whose color is not in the active
     set -- when no initial color is given, ONLY the no-color (uncolored) nodes run.
-    If a `ChangeActiveColors` event then appears in a node result with a DIFFERENT
-    color set, the run STARTS OVER with the new active set (nodes that were skipped
-    may now need to run); only the colored nodes + everything downstream of them are
-    recomputed, the rest (e.g. an upstream routing model call) is carried over so it
-    is never repeated. The restart happens at most once (the color resolves once).
+    If `ChangeActiveColors` events then appear in node results whose UNION differs
+    from the active set, the run STARTS OVER with that union as the new active set
+    (nodes that were skipped may now need to run); only the colored nodes +
+    everything downstream of them are recomputed, the rest (e.g. an upstream routing
+    model call) is carried over so it is never repeated. The run restarts until the
+    unioned declaration stabilizes (normally once); a union cycling back to an
+    earlier active set raises `ColorDeclarationsDidNotConverge`.
     """
 
     node_to_colors: Mapping[base_types.ComputationNode, FrozenSet]
@@ -595,11 +610,19 @@ async def _run_graph_async(
     # set, disjoint from every color, so only the no-color (uncolored) nodes run.
     active = initial_colors if initial_colors is not None else frozenset()
 
+    _skip_filter = os.getenv("CG_SKIP_TRACE")
+
     def _schedule_or_skip(node_executor):
         node = node_executor[0]
         colors = node_to_colors.get(node)
         if colors and colors.isdisjoint(active):
             # colored but not active: frontier -> boundary default; interior -> prune.
+            if _skip_filter and any(
+                s in str(node) for s in _skip_filter.split("|")
+            ):
+                logging.error(
+                    f"[CG-SKIP] {node} colors={sorted(map(str, colors))} active={sorted(map(str, active))}"
+                )
             if node in boundary_defaults:
                 node_to_task_or_result[node] = boundary_defaults[node]
             return
@@ -636,6 +659,7 @@ async def _run_graph_async(
         # Same restart loop as the sync runner, but a node's result is a Task we must
         # await. We schedule the whole pass first (the tasks run CONCURRENTLY), then
         # gather them together (not one-by-one) before checking for a color change.
+        seen_active_sets = {active}
         while True:
             for node_executor in topological_sorted_nodes:
                 if node_executor[0] in node_to_task_or_result:
@@ -646,15 +670,30 @@ async def _run_graph_async(
             harvested = await _gather_pending()
             if harvested is not None:
                 raise harvested
-            # The LAST change-color event in the pass wins.
-            observed = None
-            for node_executor in topological_sorted_nodes:
-                value = node_to_task_or_result.get(node_executor[0], CG_NO_RESULT)
-                if isinstance(value, ChangeActiveColors):
-                    observed = value.colors
-            if observed is None or observed == active:
+            # Declarations COMPOSE: the pass's active set is the UNION of every
+            # ChangeActiveColors observed (independent declarers each contribute the
+            # colors they resolved; an empty declaration contributes nothing).
+            declarations = frozenset(
+                value
+                for node_executor in topological_sorted_nodes
+                for value in (
+                    node_to_task_or_result.get(node_executor[0], CG_NO_RESULT),
+                )
+                if isinstance(value, ChangeActiveColors)
+            )
+            if not declarations:
+                break  # nothing declared -> the seed stands
+            observed = frozenset().union(*(d.colors for d in declarations))
+            if observed == active:
                 break  # no new color -> done
-            # A different color was declared -> START OVER with it, recomputing only
+            # Revisiting an earlier active set means the declarations depend on the
+            # active colors themselves -> the loop can never settle; fail loudly.
+            if observed in seen_active_sets:
+                raise ColorDeclarationsDidNotConverge(
+                    f"{sorted(map(str, observed))} was already active this run"
+                )
+            seen_active_sets.add(observed)
+            # A new color set was declared -> START OVER with it, recomputing only
             # the color-dependent nodes; the rest (routing / async work) carry over.
             active = observed
             for node in tuple(node_to_task_or_result):
@@ -695,9 +734,11 @@ def _run_graph(
     # the rest over. With no coloring (`to_callable`) the loop runs the whole graph
     # once, exactly as before.
     active = initial_colors if initial_colors is not None else frozenset()
-    restart = True
-    while restart:
-        restart = False
+    # Same restart loop as the async runner: run the WHOLE pass, then union the
+    # declarations (a later declarer in the toposort must be seen before deciding
+    # the active set), and start over if a new color set was declared.
+    seen_active_sets = {active}
+    while True:
         for node_executor in topological_sorted_nodes:
             node = node_executor[0]
             if node in accumulated_results:
@@ -709,20 +750,35 @@ def _run_graph(
                     accumulated_results[node] = boundary_defaults[node]
                 continue
             _schedule_node(node_executor, accumulated_results, handled_exceptions)
-            value = accumulated_results.get(node, CG_NO_RESULT)
-            # A node that declares a NEW active color -> start over with it,
-            # recomputing only the color-dependent nodes (routing/core carry over).
-            if (
-                color_dependent
-                and isinstance(value, ChangeActiveColors)
-                and value.colors != active
-            ):
-                active = value.colors
-                for n in tuple(accumulated_results):
-                    if n in color_dependent:
-                        del accumulated_results[n]
-                restart = True
-                break
+        if not color_dependent:
+            break  # no colored nodes -> nothing to restart for
+        # Declarations COMPOSE: the pass's active set is the UNION of every
+        # ChangeActiveColors observed (independent declarers each contribute the
+        # colors they resolved; an empty declaration contributes nothing).
+        declarations = frozenset(
+            value
+            for node_executor in topological_sorted_nodes
+            for value in (accumulated_results.get(node_executor[0], CG_NO_RESULT),)
+            if isinstance(value, ChangeActiveColors)
+        )
+        if not declarations:
+            break  # nothing declared -> the seed stands
+        observed = frozenset().union(*(d.colors for d in declarations))
+        if observed == active:
+            break  # no new color -> done
+        # Revisiting an earlier active set means the declarations depend on the
+        # active colors themselves -> the loop can never settle; fail loudly.
+        if observed in seen_active_sets:
+            raise ColorDeclarationsDidNotConverge(
+                f"{sorted(map(str, observed))} was already active this run"
+            )
+        seen_active_sets.add(observed)
+        # A new color set was declared -> start over with it, recomputing only the
+        # color-dependent nodes (routing/core carry over).
+        active = observed
+        for n in tuple(accumulated_results):
+            if n in color_dependent:
+                del accumulated_results[n]
     return accumulated_results
 
 

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -1,0 +1,240 @@
+"""Tests for the opt-in per-node skipping ("coloring") in run.to_callable.
+
+The engine is domain-agnostic: it knows only COLORS (opaque tokens) and the
+`run.ChangeActiveColors` event. The CALLER passes the initial active colors when it
+starts the run (the reducer's `active_colors` argument; optional). Colored nodes
+whose color is not active skip; with no initial color, only the no-color nodes run.
+If a node then RETURNS `run.ChangeActiveColors(other)` the run STARTS OVER with the
+new color set (nodes skipped on the first pass may now need to run). Validates:
+  * a SKIPPED BOUNDARY node returns its typed-empty default (downstream make_and
+    stays well-formed); a SKIPPED INTERIOR node (no default) prunes (absent);
+  * the caller's initial color selects which skill runs (single pass);
+  * a ChangeActiveColors event restarts the run to the newly-active color.
+"""
+import asyncio
+
+from computation_graph import base_types, composers, graph, run
+
+
+# --------------------------------------------------------------------------- #
+# Sync: skill_a/skill_b colored {A}/{B}; combine is make_and over both. The
+# caller passes the active color directly.
+# --------------------------------------------------------------------------- #
+def _build(calls):
+    def skill_a(x):
+        calls.append("A")
+        return ("A", x)
+
+    def skill_b(x):
+        calls.append("B")
+        return ("B", x)
+
+    def combine(a, b):
+        return (a, b)
+
+    x_source = graph.make_source()
+    g = base_types.merge_graphs(
+        composers.compose_left_future(x_source, skill_a, None, None),
+        composers.compose_left_future(x_source, skill_b, None, None),
+        composers.compose_dict(combine, {"a": skill_a, "b": skill_b}),
+    )
+    nodes = {
+        "a": graph.make_computation_node(skill_a),
+        "b": graph.make_computation_node(skill_b),
+        "combine": graph.make_computation_node(combine),
+    }
+    return g, x_source, nodes
+
+
+def _activation(nodes):
+    return run.NodeActivation(
+        node_to_colors={nodes["a"]: frozenset({"A"}), nodes["b"]: frozenset({"B"})},
+        boundary_defaults={nodes["a"]: ("A", "EMPTY"), nodes["b"]: ("B", "EMPTY")},
+    )
+
+
+def test_initial_color_runs_matching_skill():
+    calls = []
+    g, x_source, nodes = _build(calls)
+    f = run.to_callable_with_node_activation(g, frozenset(), _activation(nodes))
+
+    result = f({}, {x_source: 5}, frozenset({"A"}))  # caller provides color A
+
+    assert calls == ["A"]  # only A ran; B's boundary default flowed into make_and
+    assert result[nodes["combine"]] == (("A", 5), ("B", "EMPTY"))
+
+
+def test_other_initial_color():
+    calls = []
+    g, x_source, nodes = _build(calls)
+    f = run.to_callable_with_node_activation(g, frozenset(), _activation(nodes))
+
+    result = f({}, {x_source: 7}, frozenset({"B"}))
+
+    assert calls == ["B"]
+    assert result[nodes["combine"]] == (("A", "EMPTY"), ("B", 7))
+
+
+def test_no_initial_color_skips_all_colored():
+    calls = []
+    g, x_source, nodes = _build(calls)
+    f = run.to_callable_with_node_activation(g, frozenset(), _activation(nodes))
+
+    result = f({}, {x_source: 5})  # no color -> only no-color nodes run
+
+    assert calls == []
+    assert result[nodes["combine"]] == (("A", "EMPTY"), ("B", "EMPTY"))
+
+
+
+def test_interior_node_prunes_when_skipped():
+    """A colored node with NO boundary default prunes (absent) when inactive."""
+    calls = []
+
+    def worker(x):
+        calls.append("worker")
+        return ("worked", x)
+
+    x_source = graph.make_source()
+    g = composers.compose_left_future(x_source, worker, None, None)
+    worker_node = graph.make_computation_node(worker)
+
+    activation = run.NodeActivation(
+        node_to_colors={worker_node: frozenset({"A"})}, boundary_defaults={}
+    )
+    f = run.to_callable_with_node_activation(g, frozenset(), activation)
+
+    skipped = f({}, {x_source: 9}, frozenset({"B"}))  # B active -> worker(A) prunes
+    assert calls == []
+    assert worker_node not in skipped
+
+    ran = f({}, {x_source: 9}, frozenset({"A"}))  # A active -> worker runs
+    assert calls == ["worker"]
+    assert ran[worker_node] == ("worked", 9)
+
+
+def test_sync_change_event_restarts():
+    """A node emits ChangeActiveColors; with no initial color the first pass skips
+    the colored node, the event restarts the run, and it then runs."""
+    calls = []
+
+    def router(sel):
+        return run.ChangeActiveColors(frozenset({sel}))  # the change-color event
+
+    def worker(x):
+        calls.append("worker")
+        return ("worked", x)
+
+    sel_source = graph.make_source()
+    x_source = graph.make_source()
+    g = base_types.merge_graphs(
+        composers.compose_left_future(sel_source, router, None, None),
+        composers.compose_left_future(x_source, worker, None, None),
+    )
+    worker_node = graph.make_computation_node(worker)
+    activation = run.NodeActivation(
+        node_to_colors={worker_node: frozenset({"A"})}, boundary_defaults={}
+    )
+    f = run.to_callable_with_node_activation(g, frozenset(), activation)
+
+    # No initial color -> worker(A) skipped on pass 0; router emits A -> restart.
+    result = f({}, {sel_source: "A", x_source: 9})
+    assert calls == ["worker"]
+    assert result[worker_node] == ("worked", 9)
+
+
+# --------------------------------------------------------------------------- #
+# Async: the change-color event is downstream of an async VIC, so it isn't known
+# when the colored nodes would first run -> the run starts over once the event
+# is observed.
+# --------------------------------------------------------------------------- #
+def _build_async():
+    calls = []
+
+    async def vic(utterance):
+        await asyncio.sleep(0)  # genuinely async
+        return utterance  # a color index, or None for "no skill"
+
+    def chosen_skill_id(v):
+        return v  # raw, consumed by select
+
+    def route_color(v):  # the change-color event
+        return run.ChangeActiveColors(frozenset() if v is None else frozenset({v}))
+
+    def skill_a(x):
+        calls.append("A")
+        return ("A", x)
+
+    def skill_b(x):
+        calls.append("B")
+        return ("B", x)
+
+    def aggregate(a, b):
+        return [a, b]
+
+    def select(chosen, agg):
+        return ("NONE",) if chosen is None else agg[chosen]
+
+    u = graph.make_source()
+    s = graph.make_source()
+    g = base_types.merge_graphs(
+        composers.compose_left_future(u, vic, None, None),
+        composers.compose_left_unary(vic, chosen_skill_id),
+        composers.compose_left_unary(vic, route_color),
+        composers.compose_left_future(s, skill_a, None, None),
+        composers.compose_left_future(s, skill_b, None, None),
+        composers.compose_dict(aggregate, {"a": skill_a, "b": skill_b}),
+        composers.compose_dict(select, {"chosen": chosen_skill_id, "agg": aggregate}),
+    )
+    nodes = {
+        "a": graph.make_computation_node(skill_a),
+        "b": graph.make_computation_node(skill_b),
+        "select": graph.make_computation_node(select),
+    }
+    return g, u, s, nodes, calls
+
+
+def _async_activation(nodes):
+    return run.NodeActivation(
+        node_to_colors={nodes["a"]: frozenset({0}), nodes["b"]: frozenset({1})},
+        boundary_defaults={nodes["a"]: ("A", "EMPTY"), nodes["b"]: ("B", "EMPTY")},
+    )
+
+
+async def test_async_change_event_routes_to_chosen_skill():
+    g, u, s, nodes, calls = _build_async()
+    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+
+    result = await f({}, {u: 0, s: 5})  # no initial color; event resolves skill 0
+    assert calls == ["A"]
+    assert result[nodes["select"]] == ("A", 5)
+
+
+async def test_async_greeting_no_skill_skips_all():
+    g, u, s, nodes, calls = _build_async()
+    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+
+    result = await f({}, {u: None, s: 5})  # event resolves empty -> skip all colored
+    assert calls == []
+    assert result[nodes["select"]] == ("NONE",)
+
+
+async def test_async_initial_color_single_pass():
+    g, u, s, nodes, calls = _build_async()
+    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+
+    # Caller seeds color 0 and the route event agrees -> single pass, no restart.
+    result = await f({}, {u: 0, s: 5}, frozenset({0}))
+    assert calls == ["A"]
+    assert result[nodes["select"]] == ("A", 5)
+
+
+async def test_async_reroute_restarts():
+    g, u, s, nodes, calls = _build_async()
+    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+
+    # Caller seeds color 0, but the route event resolves color 1 -> restart to B.
+    result = await f({}, {u: 1, s: 5}, frozenset({0}))
+    assert calls == ["A", "B"]  # A ran on the seeded pass, then restarted to B
+    assert result[nodes["select"]] == ("B", 5)
+

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -1,14 +1,15 @@
 """Tests for the opt-in per-node skipping ("coloring") in run.to_callable.
 
 The engine is domain-agnostic: it knows only COLORS (opaque tokens) and the
-`run.ChangeActiveColors` event. Every run starts with no active colors, so only
-the no-color nodes run; when a node RETURNS `run.ChangeActiveColors(...)` the run
-STARTS OVER with the union of the declared color sets (nodes skipped on the first
-pass may now need to run). Validates:
+`run.ChangeActiveColors` event. The CALLER passes the initial active colors when it
+starts the run (the reducer's `active_colors` argument; optional). Colored nodes
+whose color is not active skip; with no initial color, only the no-color nodes run.
+If a node then RETURNS `run.ChangeActiveColors(other)` the run STARTS OVER with the
+new color set (nodes skipped on the first pass may now need to run). Validates:
   * a SKIPPED BOUNDARY node returns its typed-empty default (downstream make_and
     stays well-formed); a SKIPPED INTERIOR node (no default) prunes (absent);
-  * a ChangeActiveColors declaration restarts the run to the newly-active colors;
-  * declarations from independent nodes UNION rather than cancel.
+  * the caller's initial color selects which skill runs (single pass);
+  * a ChangeActiveColors event restarts the run to the newly-active color.
 """
 import asyncio
 
@@ -28,7 +29,8 @@ def _to_callable(edges, activation):
 
 
 # --------------------------------------------------------------------------- #
-# Sync: skill_a/skill_b colored {A}/{B}; combine is make_and over both.
+# Sync: skill_a/skill_b colored {A}/{B}; combine is make_and over both. The
+# caller passes the active color directly.
 # --------------------------------------------------------------------------- #
 def _build(calls):
     def skill_a(x):
@@ -63,7 +65,29 @@ def _activation(nodes):
     )
 
 
-def test_colored_nodes_skip_without_declaration():
+def test_initial_color_runs_matching_skill():
+    calls = []
+    g, x_source, nodes = _build(calls)
+    f = _to_callable(g, _activation(nodes))
+
+    result = f({}, {x_source: 5}, frozenset({"A"}))  # caller provides color A
+
+    assert calls == ["A"]  # only A ran; B's boundary default flowed into make_and
+    assert result[nodes["combine"]] == (("A", 5), ("B", "EMPTY"))
+
+
+def test_other_initial_color():
+    calls = []
+    g, x_source, nodes = _build(calls)
+    f = _to_callable(g, _activation(nodes))
+
+    result = f({}, {x_source: 7}, frozenset({"B"}))
+
+    assert calls == ["B"]
+    assert result[nodes["combine"]] == (("A", "EMPTY"), ("B", 7))
+
+
+def test_no_initial_color_skips_all_colored():
     calls = []
     g, x_source, nodes = _build(calls)
     f = _to_callable(g, _activation(nodes))
@@ -87,24 +111,16 @@ def test_interior_node_prunes_when_skipped():
     g = composers.compose_left_future(x_source, worker, None, None)
     worker_node = graph.make_computation_node(worker)
 
-    sel = graph.make_source()
-
-    def declare(colors):
-        return run.ChangeActiveColors(frozenset(colors))
-
-    g = base_types.merge_graphs(
-        g, composers.compose_left_future(sel, declare, None, None)
-    )
     activation = run.NodeActivation(
         node_to_colors={worker_node: frozenset({"A"})}, boundary_defaults={}
     )
     f = _to_callable(g, activation)
 
-    skipped = f({}, {x_source: 9, sel: {"B"}})  # B declared -> worker(A) prunes
+    skipped = f({}, {x_source: 9}, frozenset({"B"}))  # B active -> worker(A) prunes
     assert calls == []
     assert worker_node not in skipped
 
-    ran = f({}, {x_source: 9, sel: {"A"}})  # A declared -> worker runs
+    ran = f({}, {x_source: 9}, frozenset({"A"}))  # A active -> worker runs
     assert calls == ["worker"]
     assert ran[worker_node] == ("worked", 9)
 
@@ -213,6 +229,27 @@ async def test_async_greeting_no_skill_skips_all():
     result = await f({}, {u: None, s: 5})  # event resolves empty -> skip all colored
     assert calls == []
     assert result[nodes["select"]] == ("NONE",)
+
+
+async def test_async_initial_color_single_pass():
+    g, u, s, nodes, calls = _build_async()
+    f = _to_callable(g, _async_activation(nodes))
+
+    # Caller seeds color 0 and the route event agrees -> single pass, no restart.
+    result = await f({}, {u: 0, s: 5}, frozenset({0}))
+    assert calls == ["A"]
+    assert result[nodes["select"]] == ("A", 5)
+
+
+async def test_async_reroute_restarts():
+    g, u, s, nodes, calls = _build_async()
+    f = _to_callable(g, _async_activation(nodes))
+
+    # Caller seeds color 0, but the route event resolves color 1 -> restart to B.
+    result = await f({}, {u: 1, s: 5}, frozenset({0}))
+    assert calls == ["A", "B"]  # A ran on the seeded pass, then restarted to B
+    assert result[nodes["select"]] == ("B", 5)
+
 
 
 # --------------------------------------------------------------------------- #

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -13,7 +13,19 @@ new color set (nodes skipped on the first pass may now need to run). Validates:
 """
 import asyncio
 
+import gamla
+
 from computation_graph import base_types, composers, graph, run
+
+
+def _to_callable(edges, activation):
+    # Compile a graph with an explicit, hand-built NodeActivation (production derives
+    # one from tags via `run.to_callable_with_coloring`; these tests drive the runner
+    # skipping directly). Same null-side-effect path as `run.to_callable`, with the
+    # activation forwarded as its trailing argument.
+    return run.to_callable_with_side_effect(
+        gamla.just(gamla.just(None)), edges, frozenset(), activation
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -56,7 +68,7 @@ def _activation(nodes):
 def test_initial_color_runs_matching_skill():
     calls = []
     g, x_source, nodes = _build(calls)
-    f = run.to_callable_with_node_activation(g, frozenset(), _activation(nodes))
+    f = _to_callable(g, _activation(nodes))
 
     result = f({}, {x_source: 5}, frozenset({"A"}))  # caller provides color A
 
@@ -67,7 +79,7 @@ def test_initial_color_runs_matching_skill():
 def test_other_initial_color():
     calls = []
     g, x_source, nodes = _build(calls)
-    f = run.to_callable_with_node_activation(g, frozenset(), _activation(nodes))
+    f = _to_callable(g, _activation(nodes))
 
     result = f({}, {x_source: 7}, frozenset({"B"}))
 
@@ -78,7 +90,7 @@ def test_other_initial_color():
 def test_no_initial_color_skips_all_colored():
     calls = []
     g, x_source, nodes = _build(calls)
-    f = run.to_callable_with_node_activation(g, frozenset(), _activation(nodes))
+    f = _to_callable(g, _activation(nodes))
 
     result = f({}, {x_source: 5})  # no color -> only no-color nodes run
 
@@ -102,7 +114,7 @@ def test_interior_node_prunes_when_skipped():
     activation = run.NodeActivation(
         node_to_colors={worker_node: frozenset({"A"})}, boundary_defaults={}
     )
-    f = run.to_callable_with_node_activation(g, frozenset(), activation)
+    f = _to_callable(g, activation)
 
     skipped = f({}, {x_source: 9}, frozenset({"B"}))  # B active -> worker(A) prunes
     assert calls == []
@@ -135,7 +147,7 @@ def test_sync_change_event_restarts():
     activation = run.NodeActivation(
         node_to_colors={worker_node: frozenset({"A"})}, boundary_defaults={}
     )
-    f = run.to_callable_with_node_activation(g, frozenset(), activation)
+    f = _to_callable(g, activation)
 
     # No initial color -> worker(A) skipped on pass 0; router emits A -> restart.
     result = f({}, {sel_source: "A", x_source: 9})
@@ -203,7 +215,7 @@ def _async_activation(nodes):
 
 async def test_async_change_event_routes_to_chosen_skill():
     g, u, s, nodes, calls = _build_async()
-    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+    f = _to_callable(g, _async_activation(nodes))
 
     result = await f({}, {u: 0, s: 5})  # no initial color; event resolves skill 0
     assert calls == ["A"]
@@ -212,7 +224,7 @@ async def test_async_change_event_routes_to_chosen_skill():
 
 async def test_async_greeting_no_skill_skips_all():
     g, u, s, nodes, calls = _build_async()
-    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+    f = _to_callable(g, _async_activation(nodes))
 
     result = await f({}, {u: None, s: 5})  # event resolves empty -> skip all colored
     assert calls == []
@@ -221,7 +233,7 @@ async def test_async_greeting_no_skill_skips_all():
 
 async def test_async_initial_color_single_pass():
     g, u, s, nodes, calls = _build_async()
-    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+    f = _to_callable(g, _async_activation(nodes))
 
     # Caller seeds color 0 and the route event agrees -> single pass, no restart.
     result = await f({}, {u: 0, s: 5}, frozenset({0}))
@@ -231,7 +243,7 @@ async def test_async_initial_color_single_pass():
 
 async def test_async_reroute_restarts():
     g, u, s, nodes, calls = _build_async()
-    f = run.to_callable_with_node_activation(g, frozenset(), _async_activation(nodes))
+    f = _to_callable(g, _async_activation(nodes))
 
     # Caller seeds color 0, but the route event resolves color 1 -> restart to B.
     result = await f({}, {u: 1, s: 5}, frozenset({0}))

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -45,10 +45,12 @@ def _build(calls):
         return (a, b)
 
     x_source = graph.make_source()
-    g = base_types.merge_graphs(
+    combine_graph = composers.compose_dict(combine, {"a": skill_a, "b": skill_b})
+    g = graph.merge_graphs(
         composers.compose_left_future(x_source, skill_a, None, None),
         composers.compose_left_future(x_source, skill_b, None, None),
-        composers.compose_dict(combine, {"a": skill_a, "b": skill_b}),
+        combine_graph,
+        sink_node_or_graph=combine_graph,
     )
     nodes = {
         "a": graph.make_computation_node(skill_a),
@@ -139,9 +141,11 @@ def test_sync_change_event_restarts():
 
     sel_source = graph.make_source()
     x_source = graph.make_source()
-    g = base_types.merge_graphs(
+    worker_graph = composers.compose_left_future(x_source, worker, None, None)
+    g = graph.merge_graphs(
         composers.compose_left_future(sel_source, router, None, None),
-        composers.compose_left_future(x_source, worker, None, None),
+        worker_graph,
+        sink_node_or_graph=worker_graph,
     )
     worker_node = graph.make_computation_node(worker)
     activation = run.NodeActivation(
@@ -189,14 +193,18 @@ def _build_async():
 
     u = graph.make_source()
     s = graph.make_source()
-    g = base_types.merge_graphs(
+    select_graph = composers.compose_dict(
+        select, {"chosen": chosen_skill_id, "agg": aggregate}
+    )
+    g = graph.merge_graphs(
         composers.compose_left_future(u, vic, None, None),
         composers.compose_left_unary(vic, chosen_skill_id),
         composers.compose_left_unary(vic, route_color),
         composers.compose_left_future(s, skill_a, None, None),
         composers.compose_left_future(s, skill_b, None, None),
         composers.compose_dict(aggregate, {"a": skill_a, "b": skill_b}),
-        composers.compose_dict(select, {"chosen": chosen_skill_id, "agg": aggregate}),
+        select_graph,
+        sink_node_or_graph=select_graph,
     )
     nodes = {
         "a": graph.make_computation_node(skill_a),
@@ -276,11 +284,13 @@ def _build_two_declarers(calls, colors_one, colors_two):
 
     u = graph.make_source()
     s = graph.make_source()
-    g = base_types.merge_graphs(
+    skill_b_graph = composers.compose_left_future(s, skill_b, None, None)
+    g = graph.merge_graphs(
         composers.compose_left_future(u, declarer_one, None, None),
         composers.compose_left_future(u, declarer_two, None, None),
         composers.compose_left_future(s, skill_a, None, None),
-        composers.compose_left_future(s, skill_b, None, None),
+        skill_b_graph,
+        sink_node_or_graph=skill_b_graph,
     )
     activation = run.NodeActivation(
         node_to_colors={
@@ -338,12 +348,14 @@ async def test_async_declarations_union():
 
     u = graph.make_source()
     s = graph.make_source()
-    g = base_types.merge_graphs(
+    skill_b_graph = composers.compose_left_future(s, skill_b, None, None)
+    g = graph.merge_graphs(
         composers.compose_left_future(u, vic, None, None),
         composers.compose_left_unary(vic, declarer_one),
         composers.compose_left_unary(vic, declarer_two),
         composers.compose_left_future(s, skill_a, None, None),
-        composers.compose_left_future(s, skill_b, None, None),
+        skill_b_graph,
+        sink_node_or_graph=skill_b_graph,
     )
     activation = run.NodeActivation(
         node_to_colors={

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -1,15 +1,14 @@
 """Tests for the opt-in per-node skipping ("coloring") in run.to_callable.
 
 The engine is domain-agnostic: it knows only COLORS (opaque tokens) and the
-`run.ChangeActiveColors` event. The CALLER passes the initial active colors when it
-starts the run (the reducer's `active_colors` argument; optional). Colored nodes
-whose color is not active skip; with no initial color, only the no-color nodes run.
-If a node then RETURNS `run.ChangeActiveColors(other)` the run STARTS OVER with the
-new color set (nodes skipped on the first pass may now need to run). Validates:
+`run.ChangeActiveColors` event. Every run starts with no active colors, so only
+the no-color nodes run; when a node RETURNS `run.ChangeActiveColors(...)` the run
+STARTS OVER with the union of the declared color sets (nodes skipped on the first
+pass may now need to run). Validates:
   * a SKIPPED BOUNDARY node returns its typed-empty default (downstream make_and
     stays well-formed); a SKIPPED INTERIOR node (no default) prunes (absent);
-  * the caller's initial color selects which skill runs (single pass);
-  * a ChangeActiveColors event restarts the run to the newly-active color.
+  * a ChangeActiveColors declaration restarts the run to the newly-active colors;
+  * declarations from independent nodes UNION rather than cancel.
 """
 import asyncio
 
@@ -29,8 +28,7 @@ def _to_callable(edges, activation):
 
 
 # --------------------------------------------------------------------------- #
-# Sync: skill_a/skill_b colored {A}/{B}; combine is make_and over both. The
-# caller passes the active color directly.
+# Sync: skill_a/skill_b colored {A}/{B}; combine is make_and over both.
 # --------------------------------------------------------------------------- #
 def _build(calls):
     def skill_a(x):
@@ -65,29 +63,7 @@ def _activation(nodes):
     )
 
 
-def test_initial_color_runs_matching_skill():
-    calls = []
-    g, x_source, nodes = _build(calls)
-    f = _to_callable(g, _activation(nodes))
-
-    result = f({}, {x_source: 5}, frozenset({"A"}))  # caller provides color A
-
-    assert calls == ["A"]  # only A ran; B's boundary default flowed into make_and
-    assert result[nodes["combine"]] == (("A", 5), ("B", "EMPTY"))
-
-
-def test_other_initial_color():
-    calls = []
-    g, x_source, nodes = _build(calls)
-    f = _to_callable(g, _activation(nodes))
-
-    result = f({}, {x_source: 7}, frozenset({"B"}))
-
-    assert calls == ["B"]
-    assert result[nodes["combine"]] == (("A", "EMPTY"), ("B", 7))
-
-
-def test_no_initial_color_skips_all_colored():
+def test_colored_nodes_skip_without_declaration():
     calls = []
     g, x_source, nodes = _build(calls)
     f = _to_callable(g, _activation(nodes))
@@ -111,16 +87,24 @@ def test_interior_node_prunes_when_skipped():
     g = composers.compose_left_future(x_source, worker, None, None)
     worker_node = graph.make_computation_node(worker)
 
+    sel = graph.make_source()
+
+    def declare(colors):
+        return run.ChangeActiveColors(frozenset(colors))
+
+    g = base_types.merge_graphs(
+        g, composers.compose_left_future(sel, declare, None, None)
+    )
     activation = run.NodeActivation(
         node_to_colors={worker_node: frozenset({"A"})}, boundary_defaults={}
     )
     f = _to_callable(g, activation)
 
-    skipped = f({}, {x_source: 9}, frozenset({"B"}))  # B active -> worker(A) prunes
+    skipped = f({}, {x_source: 9, sel: {"B"}})  # B declared -> worker(A) prunes
     assert calls == []
     assert worker_node not in skipped
 
-    ran = f({}, {x_source: 9}, frozenset({"A"}))  # A active -> worker runs
+    ran = f({}, {x_source: 9, sel: {"A"}})  # A declared -> worker runs
     assert calls == ["worker"]
     assert ran[worker_node] == ("worked", 9)
 
@@ -229,27 +213,6 @@ async def test_async_greeting_no_skill_skips_all():
     result = await f({}, {u: None, s: 5})  # event resolves empty -> skip all colored
     assert calls == []
     assert result[nodes["select"]] == ("NONE",)
-
-
-async def test_async_initial_color_single_pass():
-    g, u, s, nodes, calls = _build_async()
-    f = _to_callable(g, _async_activation(nodes))
-
-    # Caller seeds color 0 and the route event agrees -> single pass, no restart.
-    result = await f({}, {u: 0, s: 5}, frozenset({0}))
-    assert calls == ["A"]
-    assert result[nodes["select"]] == ("A", 5)
-
-
-async def test_async_reroute_restarts():
-    g, u, s, nodes, calls = _build_async()
-    f = _to_callable(g, _async_activation(nodes))
-
-    # Caller seeds color 0, but the route event resolves color 1 -> restart to B.
-    result = await f({}, {u: 1, s: 5}, frozenset({0}))
-    assert calls == ["A", "B"]  # A ran on the seeded pass, then restarted to B
-    assert result[nodes["select"]] == ("B", 5)
-
 
 
 # --------------------------------------------------------------------------- #

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -250,3 +250,109 @@ async def test_async_reroute_restarts():
     assert calls == ["A", "B"]  # A ran on the seeded pass, then restarted to B
     assert result[nodes["select"]] == ("B", 5)
 
+
+
+# --------------------------------------------------------------------------- #
+# Composing declarations: independent declarers (e.g. one per routing context) each
+# contribute the colors they resolved; the runner activates the UNION observed in
+# the pass. Two declarers resolving different skills in one turn activate BOTH --
+# the multi-routing-context bug shape (one declaration silently cancelling the
+# other) cannot happen.
+# --------------------------------------------------------------------------- #
+def _build_two_declarers(calls, colors_one, colors_two):
+    def declarer_one(v):
+        return run.ChangeActiveColors(colors_one)
+
+    def declarer_two(v):
+        return run.ChangeActiveColors(colors_two)
+
+    def skill_a(x):
+        calls.append("A")
+        return ("A", x)
+
+    def skill_b(x):
+        calls.append("B")
+        return ("B", x)
+
+    u = graph.make_source()
+    s = graph.make_source()
+    g = base_types.merge_graphs(
+        composers.compose_left_future(u, declarer_one, None, None),
+        composers.compose_left_future(u, declarer_two, None, None),
+        composers.compose_left_future(s, skill_a, None, None),
+        composers.compose_left_future(s, skill_b, None, None),
+    )
+    activation = run.NodeActivation(
+        node_to_colors={
+            graph.make_computation_node(skill_a): frozenset({"A"}),
+            graph.make_computation_node(skill_b): frozenset({"B"}),
+        },
+        boundary_defaults={},
+    )
+    return g, u, s, activation
+
+
+def test_sync_declarations_union():
+    calls = []
+    g, u, s, activation = _build_two_declarers(
+        calls, frozenset({"A"}), frozenset({"B"})
+    )
+    f = _to_callable(g, activation)
+
+    f({}, {u: 1, s: 5})
+    assert sorted(calls) == ["A", "B"]  # both declared colors activated
+
+
+def test_sync_empty_declaration_does_not_veto():
+    # A declarer that resolved nothing contributes nothing; the other's color runs.
+    calls = []
+    g, u, s, activation = _build_two_declarers(
+        calls, frozenset({"A"}), frozenset()
+    )
+    f = _to_callable(g, activation)
+
+    f({}, {u: 1, s: 5})
+    assert calls == ["A"]
+
+
+async def test_async_declarations_union():
+    calls = []
+
+    async def vic(v):
+        await asyncio.sleep(0)
+        return v
+
+    def declarer_one(v):
+        return run.ChangeActiveColors(frozenset({"A"}))
+
+    def declarer_two(v):
+        return run.ChangeActiveColors(frozenset({"B"}))
+
+    def skill_a(x):
+        calls.append("A")
+        return ("A", x)
+
+    def skill_b(x):
+        calls.append("B")
+        return ("B", x)
+
+    u = graph.make_source()
+    s = graph.make_source()
+    g = base_types.merge_graphs(
+        composers.compose_left_future(u, vic, None, None),
+        composers.compose_left_unary(vic, declarer_one),
+        composers.compose_left_unary(vic, declarer_two),
+        composers.compose_left_future(s, skill_a, None, None),
+        composers.compose_left_future(s, skill_b, None, None),
+    )
+    activation = run.NodeActivation(
+        node_to_colors={
+            graph.make_computation_node(skill_a): frozenset({"A"}),
+            graph.make_computation_node(skill_b): frozenset({"B"}),
+        },
+        boundary_defaults={},
+    )
+    f = _to_callable(g, activation)
+
+    await f({}, {u: 1, s: 5})
+    assert sorted(calls) == ["A", "B"]  # both declared colors activated

--- a/computation_graph/run_node_activation_test.py
+++ b/computation_graph/run_node_activation_test.py
@@ -3,7 +3,9 @@
 The engine is domain-agnostic: it knows only COLORS (opaque tokens) and the
 `run.ChangeActiveColors` event. The CALLER passes the initial active colors when it
 starts the run (the reducer's `active_colors` argument; optional). Colored nodes
-whose color is not active skip; with no initial color, only the no-color nodes run.
+whose color is not active skip; with NO initial color (None -- no color information
+yet) the run is UNPRUNED and declarations are only recorded for next turn's seed;
+an EXPLICIT empty set prunes every colored node.
 If a node then RETURNS `run.ChangeActiveColors(other)` the run STARTS OVER with the
 new color set (nodes skipped on the first pass may now need to run). Validates:
   * a SKIPPED BOUNDARY node returns its typed-empty default (downstream make_and
@@ -89,15 +91,28 @@ def test_other_initial_color():
     assert result[nodes["combine"]] == (("A", "EMPTY"), ("B", 7))
 
 
-def test_no_initial_color_skips_all_colored():
+def test_explicit_empty_color_set_skips_all_colored():
     calls = []
     g, x_source, nodes = _build(calls)
     f = _to_callable(g, _activation(nodes))
 
-    result = f({}, {x_source: 5})  # no color -> only no-color nodes run
+    result = f({}, {x_source: 5}, frozenset())  # explicit empty -> prune all colored
 
     assert calls == []
     assert result[nodes["combine"]] == (("A", "EMPTY"), ("B", "EMPTY"))
+
+
+def test_no_initial_color_runs_unpruned():
+    # None = no color information yet (a conversation's first turns): nothing
+    # prunes, so cross-turn state captures the opening context like `to_callable`.
+    calls = []
+    g, x_source, nodes = _build(calls)
+    f = _to_callable(g, _activation(nodes))
+
+    result = f({}, {x_source: 5})
+
+    assert sorted(calls) == ["A", "B"]
+    assert result[nodes["combine"]] == (("A", 5), ("B", 5))
 
 
 
@@ -225,16 +240,29 @@ async def test_async_change_event_routes_to_chosen_skill():
     g, u, s, nodes, calls = _build_async()
     f = _to_callable(g, _async_activation(nodes))
 
-    result = await f({}, {u: 0, s: 5})  # no initial color; event resolves skill 0
+    # explicit empty seed; the event resolves skill 0 and restarts the run
+    result = await f({}, {u: 0, s: 5}, frozenset())
     assert calls == ["A"]
     assert result[nodes["select"]] == ("A", 5)
+
+
+async def test_async_no_initial_color_unpruned_declaration_only_recorded():
+    g, u, s, nodes, calls = _build_async()
+    f = _to_callable(g, _async_activation(nodes))
+
+    result = await f({}, {u: 0, s: 5})  # no seed: unpruned; skill 0 declared
+    assert sorted(calls) == ["A", "B"]  # the declaration does NOT narrow the pass
+    assert result[nodes["select"]] == ("A", 5)
+    # ...but it IS recorded, so the caller seeds {0} (and prunes) next turn.
+    assert result[run.EFFECTIVE_ACTIVE_COLORS_KEY].colors == frozenset({0})
 
 
 async def test_async_greeting_no_skill_skips_all():
     g, u, s, nodes, calls = _build_async()
     f = _to_callable(g, _async_activation(nodes))
 
-    result = await f({}, {u: None, s: 5})  # event resolves empty -> skip all colored
+    # explicit empty seed + event resolves empty -> skip all colored
+    result = await f({}, {u: None, s: 5}, frozenset())
     assert calls == []
     assert result[nodes["select"]] == ("NONE",)
 
@@ -321,7 +349,7 @@ def test_sync_empty_declaration_does_not_veto():
     )
     f = _to_callable(g, activation)
 
-    f({}, {u: 1, s: 5})
+    f({}, {u: 1, s: 5}, frozenset())
     assert calls == ["A"]
 
 


### PR DESCRIPTION
Large voice agents compile every skill into one ~66k-node graph and run almost all of it every turn, so even no-LLM turns pay a fixed serial-plumbing floor. This adds authoring-time graph coloring: nodes are tagged with the colors they belong to (the tag rides duplication on the function itself), and the runner skips nodes whose colors aren't active this turn — deriving the whole skip plan from those tags plus a tolerance-aware analysis, with no graph surgery and the bus left intact.

The engine stays domain-agnostic: colors are opaque tokens, so nothing here knows about skills or routing. A consumer opts in by tagging at build time and emitting a change-color event; uncolored graphs behave exactly as before. On a 66k-node production agent this prunes ~53.5k nodes per turn with zero starvation versus the trusted data-flow baseline, and ~12x lower latency on no-LLM turns.

Closes CORE-8