### PR TITLE
CORE-15: input-gather fast-path in run loop (drop per-node asyncio.gather)

### DIFF
--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -276,14 +276,6 @@ def _node_incoming_edges_to_input_spec(
     )
 
 
-def _to_awaitable(v) -> Awaitable:
-    if inspect.isawaitable(v):
-        return v
-    f = asyncio.get_event_loop().create_future()
-    f.set_result(v)
-    return f
-
-
 def _make_get_node_executor(
     edges, handled_exceptions, single_node_side_effect: _SingleNodeSideEffect
 ):
@@ -300,25 +292,6 @@ def _make_get_node_executor(
             opt_gamla.maptuple(_node_incoming_edges_to_input_spec),
         )
     )
-
-    async def gather(
-        args: Tuple[Awaitable, ...], kwargs: Mapping[str, Awaitable]
-    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
-        if args or kwargs:
-            try:
-                gathered = await asyncio.gather(*args, *kwargs.values())
-                return gathered[: len(args)], dict(
-                    zip(kwargs.keys(), gathered[len(args) :])
-                )
-            except (
-                _DepNotFoundError,
-                base_types.SkipComputationError,
-                *handled_exceptions,
-            ):
-                # We delete the references to the upstream tasks to avoid circular reference (task->exception->traceback->task) and improve memory performance
-                del args, kwargs
-                raise _DepNotFoundError() from None
-        return (), {}
 
     def node_to_input_sync(
         accumulated_results: Mapping[base_types.ComputationNode, base_types.Result],
@@ -349,12 +322,20 @@ def _make_get_node_executor(
                 accumulated_results.get(kwarg, CG_NO_RESULT) is not CG_NO_RESULT
                 for kwarg in kwargs_spec.values()
             ):
+                # Resolve inputs in place: await only the still-pending ones
+                # (already-scheduled tasks, so concurrency is preserved) and pass
+                # concrete values straight through. This avoids allocating a
+                # resolved Future per concrete input and the asyncio.gather
+                # machinery; the comprehension does zero awaits when nothing is
+                # pending, so it completes without suspending.
+                args = [accumulated_results[a] for a in args_spec]
+                kwargs = {k: accumulated_results[v] for k, v in kwargs_spec.items()}
                 try:
-                    return await gather(
-                        tuple(_to_awaitable(accumulated_results[a]) for a in args_spec),
+                    return (
+                        tuple([await x if inspect.isawaitable(x) else x for x in args]),
                         {
-                            k: _to_awaitable(accumulated_results[v])
-                            for k, v in kwargs_spec.items()
+                            k: (await x if inspect.isawaitable(x) else x)
+                            for k, x in kwargs.items()
                         },
                     )
                 except (
@@ -362,7 +343,9 @@ def _make_get_node_executor(
                     base_types.SkipComputationError,
                     *handled_exceptions,
                 ):
-                    ...
+                    # Drop refs to the upstream tasks to avoid a
+                    # task -> exception -> traceback -> task reference cycle.
+                    del args, kwargs
         return None
 
     @opt_gamla.after(asyncio.create_task)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="computation-graph",
     python_requires=">=3",
-    version="65",
+    version="66",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),


### PR DESCRIPTION
## Summary
Profiling runtime turn latency on a large voice bot showed the dominant non-LLM per-turn cost is asyncio machinery, not node logic. The graph has few genuinely-async nodes, but every node *downstream* of an async one is routed through `await_deps_and_apply`, whose input gathering (`node_to_input_async`) wrapped **every** input in a resolved `Future` (`_to_awaitable`) and called `asyncio.gather` — even when the inputs were already concrete values sitting in the results dict.

This resolves node inputs in place: `await` only the still-pending tasks (already scheduled, so concurrency is preserved) and pass concrete values straight through. Removes the now-dead `_to_awaitable` and `gather` helper.
