### PR TITLE
CORE-32: sync-inline composition hot path + code-object signature fast path

### DIFF
--- a/computation_graph/composers/__init__.py
+++ b/computation_graph/composers/__init__.py
@@ -286,44 +286,36 @@ def _infer_composition_edges(
     unbound_signature = graph.unbound_signature(
         graph.get_incoming_edges_for_node(destination.edges)
     )
+    source_nodes = (
+        graph.get_all_nodes(source.edges)
+        if isinstance(source, GraphType)
+        else frozenset()
+    )
+    skip_cycle_check = isinstance(source, base_types.ComputationNode)
+    new_edges = set()
+    # The connectable-node set is order-independent (result is a frozenset), so we
+    # can iterate the cached node set instead of rescanning the edges.
+    for node in graph.get_all_nodes(destination.edges):
+        node_signature = unbound_signature(node)
+        if not (
+            key in node_signature.kwargs
+            or (key is None and signature.is_unary(node_signature))
+        ):
+            continue
+        # Do not add edges to nodes from source that are already present in destination (cycle).
+        if not skip_cycle_check and node in source_nodes:
+            continue
+        new_edges.add(
+            try_connect(destination=node, unbound_destination_signature=node_signature)
+        )
+    if not new_edges:
+        raise AssertionError(
+            f"Cannot compose, destination signature does not contain key '{key}'"
+        )
     return graph.merge_graphs(
-        gamla.sync.pipe(
-            destination,
-            gamla.attrgetter("edges"),
-            gamla.sync.mapcat(graph.get_edge_nodes),
-            gamla.unique,
-            gamla.sync.filter(
-                gamla.sync.compose_left(
-                    unbound_signature,
-                    lambda sig: key in sig.kwargs
-                    or (key is None and signature.is_unary(sig)),
-                )
-            ),
-            # Do not add edges to nodes from source that are already present in destination (cycle).
-            gamla.sync.filter(
-                lambda node: isinstance(source, base_types.ComputationNode)
-                or node
-                not in graph.get_all_nodes(
-                    source.edges if isinstance(source, GraphType) else source
-                )
-            ),
-            gamla.sync.map(
-                lambda destination_node: try_connect(
-                    destination=destination_node,
-                    unbound_destination_signature=unbound_signature(destination_node),
-                )
-            ),
-            frozenset,
-            gamla.sync.check(
-                gamla.identity,
-                AssertionError(
-                    f"Cannot compose, destination signature does not contain key '{key}'"
-                ),
-            ),
-            # Sink is a placeholder here; `merge_graphs` below sets the real sink
-            # via `sink_node_or_graph`.
-            lambda edges: GraphType(edges, None),  # type: ignore[arg-type]
-        ),
+        # Sink is a placeholder here; `merge_graphs` below sets the real sink
+        # via `sink_node_or_graph`.
+        GraphType(frozenset(new_edges), None),  # type: ignore[arg-type]
         _get_edges_from_node_or_graph(source),
         destination,
         sink_node_or_graph=_determine_sink(source, destination, is_future),

--- a/computation_graph/composers/duplication.py
+++ b/computation_graph/composers/duplication.py
@@ -1,6 +1,6 @@
-import asyncio
 import dataclasses
 import functools
+import inspect
 from typing import Dict
 
 import gamla
@@ -10,7 +10,7 @@ from computation_graph.composers import debug
 
 
 def duplicate_function(func):
-    if asyncio.iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func):
 
         @functools.wraps(func)
         async def inner(*args, **kwargs):

--- a/computation_graph/graph.py
+++ b/computation_graph/graph.py
@@ -1,6 +1,6 @@
 import dataclasses
 import functools
-from typing import Callable, Dict, FrozenSet, Optional, Tuple
+from typing import Callable, Dict, FrozenSet, Iterable, Optional, Tuple
 
 import gamla
 from gamla.optimized import sync as opt_gamla
@@ -68,7 +68,7 @@ _EMPTY_EDGE_SET: FrozenSet[base_types.ComputationEdge] = frozenset()
 
 
 def get_incoming_edges_for_node(
-    edges: FrozenSet[base_types.ComputationEdge],
+    edges: Iterable[base_types.ComputationEdge],
 ) -> Callable[[base_types.ComputationNode], FrozenSet[base_types.ComputationEdge]]:
     grouped: Dict[base_types.ComputationNode, list] = {}
     for edge in edges:

--- a/computation_graph/graph.py
+++ b/computation_graph/graph.py
@@ -64,11 +64,17 @@ def make_computation_node(
     )
 
 
-get_incoming_edges_for_node = opt_gamla.compose_left(
-    opt_gamla.groupby(base_types.edge_destination),
-    opt_gamla.valmap(frozenset),
-    gamla.dict_to_getter_with_default(frozenset()),
-)
+_EMPTY_EDGE_SET: FrozenSet[base_types.ComputationEdge] = frozenset()
+
+
+def get_incoming_edges_for_node(
+    edges: FrozenSet[base_types.ComputationEdge],
+) -> Callable[[base_types.ComputationNode], FrozenSet[base_types.ComputationEdge]]:
+    grouped: Dict[base_types.ComputationNode, list] = {}
+    for edge in edges:
+        grouped.setdefault(edge.destination, []).append(edge)
+    node_to_edges = {node: frozenset(group) for node, group in grouped.items()}
+    return lambda node: node_to_edges.get(node, _EMPTY_EDGE_SET)
 
 
 get_terminals = opt_gamla.compose_left(
@@ -95,30 +101,24 @@ def make_terminal(name: str, func: Callable) -> base_types.ComputationNode:
     )
 
 
-_keep_not_in_bound_kwargs = opt_gamla.compose_left(
-    opt_gamla.map(base_types.edge_key),
-    gamla.filter(gamla.identity),
-    frozenset,
-    gamla.contains,
-    gamla.remove,
-)
-
-
 @gamla.curry
 def unbound_signature(
     node_to_incoming_edges, node: base_types.ComputationNode
 ) -> base_types.NodeSignature:
     """Computes the new signature of unbound variables after considering internal edges."""
     incoming_edges = node_to_incoming_edges(node)
-    keep_not_in_bound_kwargs = _keep_not_in_bound_kwargs(incoming_edges)
+    bound_keys = {edge.key for edge in incoming_edges if edge.key}
+    node_signature = node.signature
     return base_types.NodeSignature(
-        is_kwargs=node.signature.is_kwargs
-        and "**kwargs" not in tuple(opt_gamla.map(base_types.edge_key)(incoming_edges))
-        and signature.is_unary(node.signature),
-        is_args=node.signature.is_args
+        is_kwargs=node_signature.is_kwargs
+        and all(edge.key != "**kwargs" for edge in incoming_edges)
+        and signature.is_unary(node_signature),
+        is_args=node_signature.is_args
         and not any(edge.args for edge in incoming_edges),
-        kwargs=tuple(keep_not_in_bound_kwargs(node.signature.kwargs)),
-        optional_kwargs=tuple(keep_not_in_bound_kwargs(node.signature.optional_kwargs)),
+        kwargs=tuple(k for k in node_signature.kwargs if k not in bound_keys),
+        optional_kwargs=tuple(
+            k for k in node_signature.optional_kwargs if k not in bound_keys
+        ),
     )
 
 
@@ -361,28 +361,20 @@ def merge_graphs(
         isinstance(x, base_types.GraphType) for x in graphs
     ), f"{graphs} not a graph"
     assert (
-        not base_types.is_computation_graph(sink_node_or_graph)
+        not isinstance(sink_node_or_graph, base_types.GraphType)
+        or not sink_node_or_graph.edges
         or sink_node_or_graph in graphs
     ), "sink graph must be one of the graphs being merged"
 
-    new_g = gamla.pipe(
-        graphs,
-        gamla.remove(gamla.equals(base_types.EMPTY_GRAPH)),
-        tuple,
-        gamla.pair_right(
-            gamla.just(
-                sink_node_or_graph.sink
-                if isinstance(sink_node_or_graph, base_types.GraphType)
-                else sink_node_or_graph
-            )
+    new_g = base_types.GraphType(
+        base_types.merge_edges(
+            *(g.edges for g in graphs if g != base_types.EMPTY_GRAPH)
         ),
-        gamla.packstack(
-            gamla.compose_left(
-                gamla.map(gamla.attrgetter("edges")), gamla.star(base_types.merge_edges)
-            ),
-            gamla.identity,
+        (
+            sink_node_or_graph.sink
+            if isinstance(sink_node_or_graph, base_types.GraphType)
+            else sink_node_or_graph
         ),
-        gamla.star(base_types.GraphType),
     )
 
     if base_types.is_debug_mode():

--- a/computation_graph/graph_runners.py
+++ b/computation_graph/graph_runners.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 from typing import Callable, Union
 
 import gamla
@@ -77,7 +77,7 @@ def unary_with_state_and_expectations(
 def variadic_with_state_and_expectations(g, sink):
     f = run.to_callable_strict(g)
 
-    if asyncio.iscoroutinefunction(f):
+    if inspect.iscoroutinefunction(f):
 
         async def inner(turns):
             prev = {}

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -109,7 +109,7 @@ _is_graph_async = opt_gamla.compose_left(
     opt_gamla.mapcat(lambda edge: (edge.source, *edge.args)),
     opt_gamla.remove(gamla.equals(None)),
     opt_gamla.map(base_types.node_implementation),
-    gamla.anymap(asyncio.iscoroutinefunction),
+    gamla.anymap(inspect.iscoroutinefunction),
 )
 
 
@@ -452,7 +452,7 @@ def _make_get_node_executor(
         return result
 
     all_nodes = graph.get_all_nodes(edges)
-    async_nodes = {n for n in all_nodes if asyncio.iscoroutinefunction(n.func)}
+    async_nodes = {n for n in all_nodes if inspect.iscoroutinefunction(n.func)}
     sync = all_nodes - async_nodes
     tf = graph.traverse_forward(edges)
     downstream_from_async = set(gamla.graph_traverse_many(async_nodes, tf))
@@ -572,7 +572,9 @@ to_callable = to_callable_with_side_effect(gamla.just(gamla.just(None)))
 
 
 def _node_is_properly_composed(
-    node_to_incoming_edges: base_types.GraphType,
+    node_to_incoming_edges: Callable[
+        [base_types.ComputationNode], FrozenSet[base_types.ComputationEdge]
+    ]
 ) -> Callable[[base_types.ComputationNode], bool]:
     return gamla.compose_left(
         graph.unbound_signature(node_to_incoming_edges),
@@ -581,7 +583,7 @@ def _node_is_properly_composed(
     )
 
 
-def _assert_composition_is_valid(g: base_types.GraphType):
+def _assert_composition_is_valid(g: typing.Iterable[base_types.ComputationEdge]):
     return opt_gamla.pipe(
         g,
         graph.get_all_nodes,

--- a/computation_graph/signature.py
+++ b/computation_graph/signature.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+import types
 from types import MappingProxyType
 from typing import Callable, FrozenSet
 
@@ -39,7 +40,7 @@ _func_parameters = gamla.compose_left(
 )
 
 
-def from_callable(func: Callable) -> base_types.NodeSignature:
+def _from_callable_via_inspect(func: Callable) -> base_types.NodeSignature:
     function_parameters = _func_parameters(func)
     return base_types.NodeSignature(
         is_args=gamla.anymap(parameter_is_star)(function_parameters),
@@ -56,6 +57,40 @@ def from_callable(func: Callable) -> base_types.NodeSignature:
             gamla.filter(_is_default),
             gamla.map(_parameter_name),
             tuple,
+        ),
+    )
+
+
+def _as_plain_function(func: Callable):
+    """The `inspect.signature`-equivalent target when it is a plain function whose
+    signature is fully described by its code object, else None (wrappers with
+    `__signature__`, partials, methods, builtins and classes need `inspect`)."""
+    unwrapped = inspect.unwrap(func, stop=lambda f: hasattr(f, "__signature__"))
+    if not isinstance(unwrapped, types.FunctionType) or hasattr(
+        unwrapped, "__signature__"
+    ):
+        return None
+    return unwrapped
+
+
+def from_callable(func: Callable) -> base_types.NodeSignature:
+    plain_function = _as_plain_function(func)
+    if plain_function is None:
+        return _from_callable_via_inspect(func)
+    code = plain_function.__code__
+    positional = code.co_varnames[: code.co_argcount]
+    keyword_only = code.co_varnames[
+        code.co_argcount : code.co_argcount + code.co_kwonlyargcount
+    ]
+    defaults = plain_function.__defaults__ or ()
+    keyword_defaults = plain_function.__kwdefaults__ or {}
+    return base_types.NodeSignature(
+        is_args=bool(code.co_flags & inspect.CO_VARARGS),
+        is_kwargs=bool(code.co_flags & inspect.CO_VARKEYWORDS),
+        kwargs=positional + keyword_only,
+        optional_kwargs=(
+            positional[len(positional) - len(defaults) :]
+            + tuple(name for name in keyword_only if name in keyword_defaults)
         ),
     )
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="computation-graph",
     python_requires=">=3",
-    version="68",
+    version="69",
     long_description=_LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=setuptools.find_namespace_packages(),


### PR DESCRIPTION
## Summary
- Rewrite the composition hot helpers in plain Python with identical semantics: `get_incoming_edges_for_node`, `unbound_signature`, `merge_graphs`, and the graph-destination branch of `_infer_composition_edges` (one unbound-signature computation per node instead of two, hoisted cycle set, iteration over the cached node set).
- Add a code-object fast path to `signature.from_callable` (reads `co_varnames`/`co_flags`/defaults directly), falling back to the inspect-based path for `__wrapped__`/`__signature__`/partial/method callables. 95% of real calls take the fast path; A/B shadow over a full skill-chain import: 0/49,198 mismatches.
- Use `inspect.iscoroutinefunction` instead of `asyncio.iscoroutinefunction` for async node detection (run.py, graph_runners.py, composers/duplication.py) — asyncio version is deprecated in Python 3.14, equivalent here.
- Verified: composed graphs fingerprint-identical (31/31 skill templates on the appointment-management import chain; built agents for atlantic_health_voice and inova identical); suite green.
- Measured: nlu-runtime `import configurable_api.build_bot` 45.5s → 31.5s; agent builds atlantic_health_voice 23.5s → 18.8s, inova 22.0s → 13.5s.
- Stacked on #86 (CORE-30); bumps version to 69.

## Jira
https://hyro-ai.atlassian.net/browse/CORE-32