### PR TITLE
GraphType cached derived fields + plain-Python graph-op hot paths

### DIFF
--- a/computation_graph/base_types.py
+++ b/computation_graph/base_types.py
@@ -58,8 +58,25 @@ class ComputationEdge:
     source: Optional[ComputationNode]
     args: Tuple[ComputationNode, ...]
     is_future: bool
+    # Edges are hashed on every frozenset construction/lookup; the fields are
+    # immutable so the hash is computed once. Excluded from __eq__/__repr__.
+    computed_hash: int = dataclasses.field(init=False, repr=False, compare=False)
 
     def __post_init__(self):
+        object.__setattr__(
+            self,
+            "computed_hash",
+            hash(
+                (
+                    self.destination,
+                    self.priority,
+                    self.key,
+                    self.source,
+                    self.args,
+                    self.is_future,
+                )
+            ),
+        )
         assert bool(self.args) != bool(
             self.source
         ), f"Edge must have a source or args, not both: {self}"
@@ -81,6 +98,9 @@ class ComputationEdge:
                 raise ComputationGraphTypeError(
                     _mismatch_message(self.key, self.source.func, self.destination.func)
                 )
+
+    def __hash__(self):
+        return self.computed_hash
 
     def __repr__(self):
         source_str = (
@@ -125,6 +145,46 @@ class GraphType:
 
     def __post_init__(self):
         assert isinstance(self.edges, frozenset), "edges must be a frozenset"
+
+    # The properties below are derived from `edges` (immutable), computed on
+    # first access and cached on the instance. Graph transformations that know
+    # how a derived value changes may pre-seed it via `seed_nodes` instead of
+    # letting the next reader recompute it from scratch.
+
+    @functools.cached_property
+    def nodes(self) -> FrozenSet[ComputationNode]:
+        result = set()
+        for edge in self.edges:
+            if edge.source is not None:
+                result.add(edge.source)
+            else:
+                result.update(edge.args)
+            result.add(edge.destination)
+        return frozenset(result)
+
+    @functools.cached_property
+    def node_to_incoming_edges(
+        self,
+    ) -> typing.Mapping[ComputationNode, FrozenSet[ComputationEdge]]:
+        grouped: dict = {}
+        for edge in self.edges:
+            grouped.setdefault(edge.destination, []).append(edge)
+        return {node: frozenset(group) for node, group in grouped.items()}
+
+    @functools.cached_property
+    def node_to_forward_neighbors(
+        self,
+    ) -> typing.Mapping[ComputationNode, FrozenSet[ComputationNode]]:
+        grouped: dict = {}
+        for edge in self.edges:
+            for source in edge.args or (edge.source,):
+                grouped.setdefault(source, set()).add(edge.destination)
+        return {node: frozenset(group) for node, group in grouped.items()}
+
+    def seed_nodes(self, nodes: FrozenSet[ComputationNode]) -> "GraphType":
+        """Pre-populate the `nodes` cache when the caller already knows it."""
+        self.__dict__["nodes"] = nodes
+        return self
 
 
 node_implementation = gamla.attrgetter("func")

--- a/computation_graph/composers/__init__.py
+++ b/computation_graph/composers/__init__.py
@@ -13,9 +13,12 @@ class _ComputationError:
     pass
 
 
-_to_computation_node_if_callable = gamla.unless(
-    gamla.is_instance(base_types.GraphType), graph.make_computation_node
-)
+def _to_computation_node_if_callable(
+    x: base_types.CallableOrNodeOrGraph,
+) -> base_types.NodeOrGraph:
+    if isinstance(x, base_types.GraphType):
+        return x
+    return graph.make_computation_node(x)
 
 
 def _get_edges_from_node_or_graph(
@@ -53,43 +56,33 @@ def make_and(
     # both, connecting `merge_node`'s output into `merge_fn` under key "args".
     merge_fn_graph = make_compose(merge_fn, merge_node, key="args")
 
-    return gamla.sync.pipe(
-        funcs,
-        gamla.sync.map(_to_computation_node_if_callable),
-        tuple,
-        gamla.sync.juxtcat(
-            gamla.sync.filter(gamla.is_instance(base_types.GraphType)),
-            gamla.sync.compose_left(
-                gamla.sync.map(
-                    lambda node_or_graph: (
-                        node_or_graph.sink
-                        if isinstance(node_or_graph, base_types.GraphType)
-                        else node_or_graph
-                    )
-                ),
-                tuple,
-                lambda nodes: base_types.GraphType(
-                    frozenset(
-                        [
-                            base_types.ComputationEdge(
-                                is_future=False,
-                                priority=0,
-                                source=None,
-                                args=nodes,
-                                destination=merge_node,
-                                key="*args",
-                            )
-                        ]
-                    ),
-                    merge_node,
-                ),
-                gamla.wrap_tuple,
-            ),
+    nodes_or_graphs = tuple(map(_to_computation_node_if_callable, funcs))
+    sinks = tuple(
+        node_or_graph.sink
+        if isinstance(node_or_graph, base_types.GraphType)
+        else node_or_graph
+        for node_or_graph in nodes_or_graphs
+    )
+    and_graph = base_types.GraphType(
+        frozenset(
+            [
+                base_types.ComputationEdge(
+                    is_future=False,
+                    priority=0,
+                    source=None,
+                    args=sinks,
+                    destination=merge_node,
+                    key="*args",
+                )
+            ]
         ),
-        tuple,
-        lambda graphs: graph.merge_graphs(
-            *graphs, merge_fn_graph, sink_node_or_graph=merge_fn_graph
-        ),
+        merge_node,
+    )
+    return graph.merge_graphs(
+        *(g for g in nodes_or_graphs if isinstance(g, base_types.GraphType)),
+        and_graph,
+        merge_fn_graph,
+        sink_node_or_graph=merge_fn_graph,
     )
 
 
@@ -103,46 +96,37 @@ def make_or(
     """
 
     def filter_computation_errors(*args):
-        return gamla.pipe(
-            args, gamla.remove(gamla.is_instance(_ComputationError)), tuple
-        )
+        return tuple(arg for arg in args if not isinstance(arg, _ComputationError))
 
     filter_node = graph.make_computation_node(filter_computation_errors)
     # `merge_fn` may be a callable/node or a whole graph; `make_compose` handles
     # both, connecting `filter_node`'s output into `merge_fn` under key "args".
     merge_fn_graph = make_compose(merge_fn, filter_node, key="args")
 
-    return gamla.sync.pipe(
-        nodes_or_graphs,
-        gamla.sync.map(make_optional(default_value=_ComputationError())),
-        tuple,
-        gamla.juxtcat(
-            gamla.identity,
-            gamla.sync.compose_left(
-                gamla.sync.map(gamla.attrgetter("sink")),
-                tuple,
-                lambda sinks: GraphType(
-                    frozenset(
-                        [
-                            base_types.ComputationEdge(
-                                is_future=False,
-                                priority=0,
-                                source=None,
-                                args=sinks,
-                                destination=filter_node,
-                                key="*args",
-                            )
-                        ]
-                    ),
-                    filter_node,
-                ),
-                gamla.wrap_tuple,
-            ),
+    optional_graphs = tuple(
+        make_optional(node_or_graph, default_value=_ComputationError())
+        for node_or_graph in nodes_or_graphs
+    )
+    or_graph = GraphType(
+        frozenset(
+            [
+                base_types.ComputationEdge(
+                    is_future=False,
+                    priority=0,
+                    source=None,
+                    args=tuple(g.sink for g in optional_graphs),
+                    destination=filter_node,
+                    key="*args",
+                )
+            ]
         ),
-        tuple,
-        lambda graphs: graph.merge_graphs(
-            *graphs, merge_fn_graph, sink_node_or_graph=merge_fn_graph
-        ),
+        filter_node,
+    )
+    return graph.merge_graphs(
+        *optional_graphs,
+        or_graph,
+        merge_fn_graph,
+        sink_node_or_graph=merge_fn_graph,
     )
 
 
@@ -161,37 +145,27 @@ def make_first(*graphs: base_types.CallableOrNodeOrGraph) -> base_types.GraphTyp
 
     sink = graph.make_computation_node(first_sink)
 
-    return graph.merge_graphs(
-        *gamla.pipe(
-            graph_or_nodes,
-            gamla.map(_get_edges_from_node_or_graph),
-            gamla.filter(gamla.is_instance(GraphType)),
-        ),
-        gamla.pipe(
-            graph_or_nodes,
-            gamla.map(
-                lambda graph_or_node: (
+    first_graph = GraphType(
+        frozenset(
+            base_types.ComputationEdge(
+                source=(
                     graph_or_node.sink
                     if isinstance(graph_or_node, GraphType)
                     else graph_or_node
-                )
-            ),
-            enumerate,
-            gamla.map(
-                gamla.star(
-                    lambda i, g: base_types.ComputationEdge(
-                        source=g,
-                        destination=sink,
-                        key="constituent_of_first",
-                        args=(),
-                        priority=i,
-                        is_future=False,
-                    )
-                )
-            ),
-            frozenset,
-            lambda edges: GraphType(edges, sink),
+                ),
+                destination=sink,
+                key="constituent_of_first",
+                args=(),
+                priority=i,
+                is_future=False,
+            )
+            for i, graph_or_node in enumerate(graph_or_nodes)
         ),
+        sink,
+    )
+    return graph.merge_graphs(
+        *(g for g in graph_or_nodes if isinstance(g, GraphType)),
+        first_graph,
         sink_node_or_graph=sink,
     )
 
@@ -233,7 +207,6 @@ def _determine_composition_sink(
     raise AssertionError("Could not compose, failed to. find a sink")
 
 
-@gamla.curry
 def _try_connect(
     source: base_types.ComputationNode,
     key: Optional[str],
@@ -257,7 +230,6 @@ def _try_connect(
     )
 
 
-@gamla.curry
 def _infer_composition_edges(
     priority: int,
     key: Optional[str],
@@ -266,12 +238,20 @@ def _infer_composition_edges(
     destination: base_types.NodeOrGraph,
 ) -> base_types.GraphType:
 
-    try_connect = _try_connect(
-        source.sink if isinstance(source, GraphType) else source,
-        key,
-        priority,
-        is_future,
-    )
+    source_sink = source.sink if isinstance(source, GraphType) else source
+
+    def try_connect(
+        destination: base_types.ComputationNode,
+        unbound_destination_signature: base_types.NodeSignature,
+    ) -> base_types.ComputationEdge:
+        return _try_connect(
+            source_sink,
+            key,
+            priority,
+            is_future,
+            destination,
+            unbound_destination_signature,
+        )
 
     if isinstance(destination, base_types.ComputationNode):
         sink = _determine_sink(source, destination, is_future)
@@ -283,47 +263,27 @@ def _infer_composition_edges(
             _get_edges_from_node_or_graph(source),
             sink_node_or_graph=sink,
         )
+    incoming_edges_by_node = destination.node_to_incoming_edges
     unbound_signature = graph.unbound_signature(
-        graph.get_incoming_edges_for_node(destination.edges)
+        lambda node: incoming_edges_by_node.get(node, frozenset())
     )
+    source_nodes = source.nodes if isinstance(source, GraphType) else None
+    new_edges = set()
+    for node in destination.nodes:
+        sig = unbound_signature(node)
+        if not (key in sig.kwargs or (key is None and signature.is_unary(sig))):
+            continue
+        # Do not add edges to nodes from source that are already present in destination (cycle).
+        if source_nodes is not None and node in source_nodes:
+            continue
+        new_edges.add(try_connect(destination=node, unbound_destination_signature=sig))
+    assert (
+        new_edges
+    ), f"Cannot compose, destination signature does not contain key '{key}'"
     return graph.merge_graphs(
-        gamla.sync.pipe(
-            destination,
-            gamla.attrgetter("edges"),
-            gamla.sync.mapcat(graph.get_edge_nodes),
-            gamla.unique,
-            gamla.sync.filter(
-                gamla.sync.compose_left(
-                    unbound_signature,
-                    lambda sig: key in sig.kwargs
-                    or (key is None and signature.is_unary(sig)),
-                )
-            ),
-            # Do not add edges to nodes from source that are already present in destination (cycle).
-            gamla.sync.filter(
-                lambda node: isinstance(source, base_types.ComputationNode)
-                or node
-                not in graph.get_all_nodes(
-                    source.edges if isinstance(source, GraphType) else source
-                )
-            ),
-            gamla.sync.map(
-                lambda destination_node: try_connect(
-                    destination=destination_node,
-                    unbound_destination_signature=unbound_signature(destination_node),
-                )
-            ),
-            frozenset,
-            gamla.sync.check(
-                gamla.identity,
-                AssertionError(
-                    f"Cannot compose, destination signature does not contain key '{key}'"
-                ),
-            ),
-            # Sink is a placeholder here; `merge_graphs` below sets the real sink
-            # via `sink_node_or_graph`.
-            lambda edges: GraphType(edges, None),  # type: ignore[arg-type]
-        ),
+        # Sink is a placeholder here; `merge_graphs` below sets the real sink
+        # via `sink_node_or_graph`.
+        GraphType(frozenset(new_edges), None),  # type: ignore[arg-type]
         _get_edges_from_node_or_graph(source),
         destination,
         sink_node_or_graph=_determine_sink(source, destination, is_future),
@@ -339,16 +299,13 @@ def _make_compose_inner(
     assert (
         len(funcs) > 1
     ), f"Only {len(funcs)} function passed to compose, need at least 2, funcs={funcs}"
-    return gamla.sync.pipe(
-        funcs,
-        reversed,
-        gamla.sync.map(_to_computation_node_if_callable),
-        gamla.sliding_window(2),
-        gamla.sync.map(gamla.star(_infer_composition_edges(priority, key, is_future))),
-        tuple,
-        lambda graphs: graph.merge_graphs(
-            *graphs, sink_node_or_graph=_determine_composition_sink(graphs)
-        ),
+    nodes_or_graphs = tuple(map(_to_computation_node_if_callable, reversed(funcs)))
+    graphs = tuple(
+        _infer_composition_edges(priority, key, is_future, source, destination)
+        for source, destination in zip(nodes_or_graphs, nodes_or_graphs[1:])
+    )
+    return graph.merge_graphs(
+        *graphs, sink_node_or_graph=_determine_composition_sink(graphs)
     )
 
 

--- a/computation_graph/composers/duplication.py
+++ b/computation_graph/composers/duplication.py
@@ -26,13 +26,17 @@ def duplicate_function(func):
 
 
 def _duplicate_computation_edge(get_duplicated_node):
-    return gamla.compose_left(
-        gamla.dataclass_transform("source", get_duplicated_node),
-        gamla.dataclass_transform("destination", get_duplicated_node),
-        gamla.dataclass_transform(
-            "args", gamla.compose_left(gamla.map(get_duplicated_node), tuple)
-        ),
-    )
+    def duplicate_computation_edge(
+        edge: base_types.ComputationEdge,
+    ) -> base_types.ComputationEdge:
+        return dataclasses.replace(
+            edge,
+            source=get_duplicated_node(edge.source),
+            destination=get_duplicated_node(edge.destination),
+            args=tuple(get_duplicated_node(arg) for arg in edge.args),
+        )
+
+    return duplicate_computation_edge
 
 
 def _signature_is_empty(signature: base_types.NodeSignature) -> bool:
@@ -57,21 +61,15 @@ def _node_to_duplicated_node(nodes):
 
 def duplicate_graph(original: base_types.GraphType) -> base_types.GraphType:
 
-    _node_to_duplicated_node_index = gamla.pipe(
-        original.edges, graph.get_all_nodes, _node_to_duplicated_node
-    )
-    get_duplicated_node = gamla.when(
-        _node_to_duplicated_node_index, _node_to_duplicated_node_index
-    )
+    _node_to_duplicated_node_index = _node_to_duplicated_node(original.nodes)
+
+    def get_duplicated_node(node):
+        duplicated = _node_to_duplicated_node_index(node)
+        return node if duplicated is None else duplicated
+
     return base_types.GraphType(
-        edges=gamla.pipe(
-            original.edges,
-            gamla.map(
-                _duplicate_computation_edge(
-                    gamla.when(get_duplicated_node, get_duplicated_node)
-                )
-            ),
-            frozenset,
+        edges=frozenset(
+            map(_duplicate_computation_edge(get_duplicated_node), original.edges)
         ),
         sink=get_duplicated_node(original.sink),
     )
@@ -100,9 +98,11 @@ def safe_replace_sources(
             )
         ),
     )
+    forward_neighbors = cg.node_to_forward_neighbors
     get_duplicate = gamla.pipe(
         gamla.graph_traverse_many(
-            source_to_replacement_dict.keys(), graph.traverse_forward(cg.edges)
+            source_to_replacement_dict.keys(),
+            lambda node: forward_neighbors.get(node, ()),
         ),
         gamla.remove(gamla.contains(source_to_replacement_dict.keys())),
         _node_to_duplicated_node,

--- a/computation_graph/graph.py
+++ b/computation_graph/graph.py
@@ -34,14 +34,20 @@ get_all_nodes = get_all_nodes_with_filter(None)
 def get_all_nodes_from_graph_with_filter(
     filter_nodes: Optional[Callable[[base_types.ComputationNode], bool]]
 ) -> Callable[[base_types.GraphType], FrozenSet[base_types.ComputationNode]]:
-    return opt_gamla.compose_left(
-        gamla.attrgetter("edges"), get_all_nodes_with_filter(filter_nodes)
-    )
+    if filter_nodes is None:
+        return gamla.attrgetter("nodes")
+    return lambda g: frozenset(filter(filter_nodes, g.nodes))
 
 
 edges_to_node_id_map = opt_gamla.compose_left(
     gamla.mapcat(get_edge_nodes), gamla.unique, enumerate, gamla.map(reversed), dict
 )
+
+
+# Nodes are pure values derived from the callable, and callables hash by
+# identity, so memoizing skips re-running `inspect.signature` for a callable
+# that already has a node (the callables are kept alive by the graphs anyway).
+_func_to_node: Dict[Callable, base_types.ComputationNode] = {}
 
 
 def make_computation_node(
@@ -50,18 +56,18 @@ def make_computation_node(
     if isinstance(func, base_types.ComputationNode):
         return func
 
-    return base_types.ComputationNode(
-        name=signature.name(func),
-        func=func,
-        signature=gamla.pipe(
-            func,
-            signature.from_callable,
-            gamla.assert_that_with_message(
-                gamla.just(str(func)), signature.is_supported
-            ),
-        ),
-        is_terminal=False,
-    )
+    node = _func_to_node.get(func)
+    if node is None:
+        node_signature = signature.from_callable(func)
+        assert signature.is_supported(node_signature), str(func)
+        node = base_types.ComputationNode(
+            name=signature.name(func),
+            func=func,
+            signature=node_signature,
+            is_terminal=False,
+        )
+        _func_to_node[func] = node
+    return node
 
 
 get_incoming_edges_for_node = opt_gamla.compose_left(
@@ -122,39 +128,50 @@ def unbound_signature(
     )
 
 
-def _node_in_edge_args(
-    x: base_types.CallableOrNode,
-) -> Callable[[base_types.ComputationEdge], bool]:
-    node = make_computation_node(x)
-
-    def node_in_edge_args(edge: base_types.ComputationEdge) -> bool:
-        return node in edge.args
-
-    return node_in_edge_args
-
-
 def _replace_source_in_edges(
     original: base_types.CallableOrNode, replacement: base_types.CallableOrNode
 ) -> Callable[[base_types.GraphType], base_types.GraphType]:
-    return gamla.compose(
-        gamla.star(base_types.GraphType),
-        gamla.stack(
-            [
-                gamla.compose(
-                    transform_edges(
-                        edge_source_equals(original), replace_edge_source(replacement)
-                    ),
-                    transform_edges(
-                        _node_in_edge_args(original),
-                        _replace_edge_source_args(original, replacement),
-                    ),
-                ),
-                gamla.identity,
-            ]
-        ),
-        tuple,
-        gamla.juxt(gamla.attrgetter("edges"), gamla.attrgetter("sink")),
-    )
+    original_node = make_computation_node(original)
+    replacement_node = make_computation_node(replacement)
+
+    def replace_source_in_edges(g: base_types.GraphType) -> base_types.GraphType:
+        if original_node == replacement_node:
+            return g
+        new_edges = []
+        original_remains_as_destination = False
+        rewrote_any = False
+        for edge in g.edges:
+            if edge.destination == original_node:
+                original_remains_as_destination = True
+            if edge.source == original_node:
+                rewrote_any = True
+                new_edges.append(dataclasses.replace(edge, source=replacement_node))
+            elif original_node in edge.args:
+                rewrote_any = True
+                new_edges.append(
+                    dataclasses.replace(
+                        edge,
+                        args=tuple(
+                            replacement_node if arg == original_node else arg
+                            for arg in edge.args
+                        ),
+                    )
+                )
+            else:
+                new_edges.append(edge)
+        result = base_types.GraphType(frozenset(new_edges), g.sink)
+        if "nodes" in g.__dict__:
+            new_nodes = g.nodes
+            if rewrote_any:
+                new_nodes = new_nodes | {replacement_node}
+                if not original_remains_as_destination:
+                    # All occurrences of `original_node` were in source positions
+                    # and were rewritten, so it is gone from the graph.
+                    new_nodes = new_nodes - {original_node}
+            result.seed_nodes(new_nodes)
+        return result
+
+    return replace_source_in_edges
 
 
 traverse_forward: Callable[
@@ -182,21 +199,20 @@ def replace_source(
     replacement: base_types.CallableOrNodeOrGraph,
     current_graph: base_types.GraphType,
 ) -> base_types.GraphType:
-    if make_computation_node(original) not in get_all_nodes(current_graph.edges):
+    if make_computation_node(original) not in current_graph.nodes:
         return current_graph
 
-    if gamla.is_instance(base_types.CallableOrNode)(replacement):
-        return _replace_source_in_edges(original, replacement)(current_graph)  # type: ignore
-
     if isinstance(replacement, base_types.GraphType):
-        return gamla.pipe(
-            current_graph,
-            _replace_source_in_edges(original, replacement.sink),
-            lambda transformed_graph: base_types.GraphType(
-                base_types.merge_edges(transformed_graph.edges, replacement.edges),
-                transformed_graph.sink,
-            ),
+        transformed_graph = _replace_source_in_edges(original, replacement.sink)(
+            current_graph
         )
+        return base_types.GraphType(
+            base_types.merge_edges(transformed_graph.edges, replacement.edges),
+            transformed_graph.sink,
+        )
+
+    if isinstance(replacement, base_types.ComputationNode) or callable(replacement):
+        return _replace_source_in_edges(original, replacement)(current_graph)
 
     raise RuntimeError(f"Unsupported relacement graph {replacement}")
 
@@ -204,22 +220,21 @@ def replace_source(
 def replace_destination(
     original: base_types.CallableOrNode, replacement: base_types.CallableOrNode
 ) -> Callable[[base_types.GraphType], base_types.GraphType]:
-    original = make_computation_node(original)
-    replacement = make_computation_node(replacement)
-    return gamla.compose(
-        gamla.star(base_types.GraphType),
-        gamla.stack(
-            [
-                transform_edges(
-                    edge_destination_equals(original),
-                    _replace_edge_destination(replacement),
-                ),
-                gamla.when(gamla.equals(original), gamla.just(replacement)),
-            ]
-        ),
-        tuple,
-        gamla.juxt(gamla.attrgetter("edges"), gamla.attrgetter("sink")),
-    )
+    original_node = make_computation_node(original)
+    replacement_node = make_computation_node(replacement)
+
+    def replace_destination_inner(g: base_types.GraphType) -> base_types.GraphType:
+        return base_types.GraphType(
+            frozenset(
+                dataclasses.replace(edge, destination=replacement_node)
+                if edge.destination == original_node
+                else edge
+                for edge in g.edges
+            ),
+            replacement_node if g.sink == original_node else g.sink,
+        )
+
+    return replace_destination_inner
 
 
 def replace_node(
@@ -263,9 +278,14 @@ def replace_nodes(
                             edge, source=source, destination=destination
                         )
                     )
-        return base_types.GraphType(
+        result = base_types.GraphType(
             edges=frozenset(new_edges), sink=node_map.get(g.sink, g.sink)
         )
+        # Every occurrence of a mapped node is rewritten, so the new node set
+        # is the old one mapped through `node_map`.
+        if "nodes" in g.__dict__:
+            result.seed_nodes(frozenset(node_map.get(n, n) for n in g.nodes))
+        return result
 
     return replace_nodes
 
@@ -308,35 +328,6 @@ def replace_edge_source(
     return gamla.dataclass_replace("source", make_computation_node(replacement))
 
 
-def _replace_edge_source_args(
-    original: base_types.CallableOrNode, replacement: base_types.CallableOrNode
-):
-    def replace_edge_source_args(
-        edge: base_types.ComputationEdge,
-    ) -> base_types.ComputationEdge:
-        return dataclasses.replace(
-            edge,
-            args=gamla.pipe(
-                edge.args,
-                gamla.map(
-                    gamla.when(
-                        gamla.equals(make_computation_node(original)),
-                        gamla.just(make_computation_node(replacement)),
-                    )
-                ),
-                tuple,
-            ),
-        )
-
-    return replace_edge_source_args
-
-
-def _replace_edge_destination(
-    replacement: base_types.CallableOrNode,
-) -> Callable[[base_types.ComputationEdge], base_types.ComputationEdge]:
-    return gamla.dataclass_replace("destination", make_computation_node(replacement))
-
-
 def _operate_on_edges(selector, transformation):
     return gamla.compose(
         gamla.star(
@@ -365,25 +356,24 @@ def merge_graphs(
         or sink_node_or_graph in graphs
     ), "sink graph must be one of the graphs being merged"
 
-    new_g = gamla.pipe(
-        graphs,
-        gamla.remove(gamla.equals(base_types.EMPTY_GRAPH)),
-        tuple,
-        gamla.pair_right(
-            gamla.just(
-                sink_node_or_graph.sink
-                if isinstance(sink_node_or_graph, base_types.GraphType)
-                else sink_node_or_graph
-            )
+    non_empty = tuple(g for g in graphs if g.edges)
+    new_g = base_types.GraphType(
+        base_types.merge_edges(*(g.edges for g in non_empty)),
+        (
+            sink_node_or_graph.sink
+            if isinstance(sink_node_or_graph, base_types.GraphType)
+            else sink_node_or_graph
         ),
-        gamla.packstack(
-            gamla.compose_left(
-                gamla.map(gamla.attrgetter("edges")), gamla.star(base_types.merge_edges)
-            ),
-            gamla.identity,
-        ),
-        gamla.star(base_types.GraphType),
     )
+    # Merged edges are exactly the union of the children's edges, so if every
+    # child already knows its nodes we can seed the union instead of having the
+    # next reader rescan all edges.
+    if all("nodes" in g.__dict__ for g in non_empty):
+        new_g.seed_nodes(
+            frozenset().union(*(g.nodes for g in non_empty))
+            if non_empty
+            else frozenset()
+        )
 
     if base_types.is_debug_mode():
         assert new_g.sink == _infer_sink_module.infer_sink(


### PR DESCRIPTION
- ComputationEdge: cache computed_hash (edges are hashed on every frozenset build/lookup; fields are immutable).
- GraphType: lazily cached derived fields — nodes, node_to_incoming_edges, node_to_forward_neighbors — plus seed_nodes() so transformations that know the node-set delta (merge_graphs, replace_nodes, replace_source) propagate the cache in O(delta) instead of forcing an O(E) rescan.
- make_computation_node: memoize by callable, skipping repeated inspect.signature work.
- replace_source / replace_destination: single-pass plain loops instead of 4 gamla-combinator passes over the edges.
- merge_graphs, make_first/make_and/make_or, _make_compose_inner, _infer_composition_edges: plain-Python hot paths (kills per-edge curried closures and hidden iscoroutinefunction checks); unbound signature computed once per candidate node using the cached incoming-edges field.
- duplication: use cached nodes/forward-neighbors fields.

Benchmark (bot-building-shaped workload, 4498 edges, 200 replaces): 3141ms -> 677ms total; replace_source 2534ms -> 289ms. All 102 tests pass; canonical graph shapes identical to master.