### PR TITLE
CORE-55: route iscoroutinefunction checks through gamla's fast checker

### DIFF
--- a/computation_graph/composers/duplication.py
+++ b/computation_graph/composers/duplication.py
@@ -1,6 +1,5 @@
 import dataclasses
 import functools
-import inspect
 from typing import Dict
 
 import gamla
@@ -10,7 +9,7 @@ from computation_graph.composers import debug
 
 
 def duplicate_function(func):
-    if inspect.iscoroutinefunction(func):
+    if gamla.is_coroutine_function(func):
 
         @functools.wraps(func)
         async def inner(*args, **kwargs):

--- a/computation_graph/graph_runners.py
+++ b/computation_graph/graph_runners.py
@@ -1,4 +1,3 @@
-import inspect
 from typing import Callable, Union
 
 import gamla
@@ -77,7 +76,7 @@ def unary_with_state_and_expectations(
 def variadic_with_state_and_expectations(g, sink):
     f = run.to_callable_strict(g)
 
-    if inspect.iscoroutinefunction(f):
+    if gamla.is_coroutine_function(f):
 
         async def inner(turns):
             prev = {}

--- a/computation_graph/run.py
+++ b/computation_graph/run.py
@@ -74,7 +74,7 @@ _toposort_nodes: Callable[
     toposort.toposort,
     # Make async functions come first in each layer so they'll start running before all the sync functions
     opt_gamla.maptuple(
-        gamla.sort_by(lambda n: 0 if inspect.iscoroutinefunction(n.func) else 1)
+        gamla.sort_by(lambda n: 0 if gamla.is_coroutine_function(n.func) else 1)
     ),
     gamla.concat,
     tuple,
@@ -109,7 +109,7 @@ _is_graph_async = opt_gamla.compose_left(
     opt_gamla.mapcat(lambda edge: (edge.source, *edge.args)),
     opt_gamla.remove(gamla.equals(None)),
     opt_gamla.map(base_types.node_implementation),
-    gamla.anymap(inspect.iscoroutinefunction),
+    gamla.anymap(gamla.is_coroutine_function),
 )
 
 
@@ -452,7 +452,7 @@ def _make_get_node_executor(
         return result
 
     all_nodes = graph.get_all_nodes(edges)
-    async_nodes = {n for n in all_nodes if inspect.iscoroutinefunction(n.func)}
+    async_nodes = {n for n in all_nodes if gamla.is_coroutine_function(n.func)}
     sync = all_nodes - async_nodes
     tf = graph.traverse_forward(edges)
     downstream_from_async = set(gamla.graph_traverse_many(async_nodes, tf))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "computation-graph"
-version = "72"
+version = "73"
 description = "Computation graph library"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Computation graph library"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "gamla",
+    "gamla==164",
     "immutables",
     "termcolor",
     "toposort",


### PR DESCRIPTION
## Summary
Swaps the 5 `inspect.iscoroutinefunction` call sites (run.py ×3, graph_runners.py, composers/duplication.py) to `gamla.is_coroutine_function` — the fast checker from [gamla PR #212](https://github.com/hyroai/gamla/pull/212) (Python 3.14 made each `inspect` check ~2.5× more expensive; these run per node/turn on the graph run loop).